### PR TITLE
feat: upgrade `prettier` to v2

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,4 +1,4 @@
 root: true
 extends:
-  - plugin:@eslint-community/mysticatea/es2015
-  - plugin:@eslint-community/mysticatea/+eslint-plugin
+    - plugin:@eslint-community/mysticatea/es2015
+    - plugin:@eslint-community/mysticatea/+eslint-plugin

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,11 @@
 version: 2
 updates:
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: daily
+    - package-ecosystem: github-actions
+      directory: /
+      schedule:
+          interval: daily
 
-  - package-ecosystem: npm
-    directory: /
-    schedule:
-      interval: daily
+    - package-ecosystem: npm
+      directory: /
+      schedule:
+          interval: daily

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,122 +1,121 @@
 name: CI
 on:
-  push:
-    branches:
-      # default semantic-release branches
-      - +([0-9])?(.{+([0-9]),x}).x
-      - main
-      - next
-      - next-major
-      - beta
-      - alpha
-  pull_request:
-  schedule:
-    - cron: 0 0 * * 0
+    push:
+        branches:
+            # default semantic-release branches
+            - +([0-9])?(.{+([0-9]),x}).x
+            - main
+            - next
+            - next-major
+            - beta
+            - alpha
+    pull_request:
+    schedule:
+        - cron: 0 0 * * 0
 
 jobs:
-  lint:
-    name: ⬣ Lint
-    runs-on: ubuntu-latest
-    steps:
-      - name: 🛑 Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
+    lint:
+        name: ⬣ Lint
+        runs-on: ubuntu-latest
+        steps:
+            - name: 🛑 Cancel Previous Runs
+              uses: styfle/cancel-workflow-action@0.11.0
 
-      - name: ⬇️ Checkout repo
-        uses: actions/checkout@v3
+            - name: ⬇️ Checkout repo
+              uses: actions/checkout@v3
 
-      - name: ⎔ Setup Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18
+            - name: ⎔ Setup Node
+              uses: actions/setup-node@v3
+              with:
+                  node-version: 18
 
-      - name: 📥 Install dependencies
-        run: npm install
+            - name: 📥 Install dependencies
+              run: npm install
 
-      - name: ▶️ Run lint script
-        run: npm run lint
+            - name: ▶️ Run lint script
+              run: npm run lint
 
-  test:
-    name:
-      🧪 Test (Node@${{ matrix.node }} - ESLint@${{ matrix.eslint }} - ${{
-      matrix.os }})
-    strategy:
-      matrix:
-        eslint: [6]
-        node: [12.22.0, 12, 14.17.0, 14, 16, 18]
-        os: [ubuntu-latest]
-        include:
-          # On other platforms
-          - os: windows-latest
-            eslint: 6
-            node: 18
-          - os: macos-latest
-            eslint: 6
-            node: 18
-          # On the minimum supported ESLint/Node.js version
-          - eslint: 6.6.0
-            node: 12.22.0
-            os: ubuntu-latest
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: 🛑 Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
+    test:
+        name:
+            🧪 Test (Node@${{ matrix.node }} - ESLint@${{ matrix.eslint }} - ${{
+            matrix.os }})
+        strategy:
+            matrix:
+                eslint: [6]
+                node: [12.22.0, 12, 14.17.0, 14, 16, 18]
+                os: [ubuntu-latest]
+                include:
+                    # On other platforms
+                    - os: windows-latest
+                      eslint: 6
+                      node: 18
+                    - os: macos-latest
+                      eslint: 6
+                      node: 18
+                    # On the minimum supported ESLint/Node.js version
+                    - eslint: 6.6.0
+                      node: 12.22.0
+                      os: ubuntu-latest
+        runs-on: ${{ matrix.os }}
+        steps:
+            - name: 🛑 Cancel Previous Runs
+              uses: styfle/cancel-workflow-action@0.11.0
 
-      - name: ⬇️ Checkout repo
-        uses: actions/checkout@v3
+            - name: ⬇️ Checkout repo
+              uses: actions/checkout@v3
 
-      - name: ⎔ Setup Node v${{ matrix.node }}
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node }}
+            - name: ⎔ Setup Node v${{ matrix.node }}
+              uses: actions/setup-node@v3
+              with:
+                  node-version: ${{ matrix.node }}
 
-      - name: 📥 Install dependencies
-        run: npm install
+            - name: 📥 Install dependencies
+              run: npm install
 
-      # - name: 📥 Install ESLint v${{ matrix.eslint }}
-      #   run: npm install --save-dev eslint@${{ matrix.eslint }}
+            # - name: 📥 Install ESLint v${{ matrix.eslint }}
+            #   run: npm install --save-dev eslint@${{ matrix.eslint }}
 
-      - name: ▶️ Run test script
-        run: npm run test
+            - name: ▶️ Run test script
+              run: npm run test
 
-      - name: ⬆️ Upload coverage report
-        uses: codecov/codecov-action@v3
+            - name: ⬆️ Upload coverage report
+              uses: codecov/codecov-action@v3
 
-  release:
-    name: 🚀 Release
-    needs: [lint, test]
-    runs-on: ubuntu-latest
-    if:
-      github.repository == 'eslint-community/eslint-plugin-mysticatea' &&
-      contains('refs/heads/main,refs/heads/next,refs/heads/beta,refs/heads/alpha',
-      github.ref) && github.event_name == 'push'
-    steps:
-      - name: 🛑 Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
+    release:
+        name: 🚀 Release
+        needs: [lint, test]
+        runs-on: ubuntu-latest
+        if: github.repository == 'eslint-community/eslint-plugin-mysticatea' &&
+            contains('refs/heads/main,refs/heads/next,refs/heads/beta,refs/heads/alpha',
+            github.ref) && github.event_name == 'push'
+        steps:
+            - name: 🛑 Cancel Previous Runs
+              uses: styfle/cancel-workflow-action@0.11.0
 
-      - name: ⬇️ Checkout repo
-        uses: actions/checkout@v3
+            - name: ⬇️ Checkout repo
+              uses: actions/checkout@v3
 
-      - name: ⎔ Setup node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18
+            - name: ⎔ Setup node
+              uses: actions/setup-node@v3
+              with:
+                  node-version: 18
 
-      - name: 📥 Install dependencies
-        run: npm install
+            - name: 📥 Install dependencies
+              run: npm install
 
-      - name: 🚀 Release
-        uses: cycjimmy/semantic-release-action@v3
-        with:
-          semantic_version: 19
-          branches: |
-            [
-              '+([0-9])?(.{+([0-9]),x}).x',
-              'main',
-              'next',
-              'next-major',
-              {name: 'beta', prerelease: true},
-              {name: 'alpha', prerelease: true}
-            ]
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+            - name: 🚀 Release
+              uses: cycjimmy/semantic-release-action@v3
+              with:
+                  semantic_version: 19
+                  branches: |
+                      [
+                        '+([0-9])?(.{+([0-9]),x}).x',
+                        'main',
+                        'next',
+                        'next-major',
+                        {name: 'beta', prerelease: true},
+                        {name: 'alpha', prerelease: true}
+                      ]
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -1,29 +1,29 @@
 name: 🥺 No Response
 
 on:
-  schedule:
-    # Schedule for five minutes after the hour, every hour
-    - cron: "5 * * * *"
+    schedule:
+        # Schedule for five minutes after the hour, every hour
+        - cron: "5 * * * *"
 
 permissions:
-  issues: write
-  pull-requests: write
+    issues: write
+    pull-requests: write
 
 jobs:
-  stale:
-    if: github.repository == 'eslint-community/eslint-plugin-mysticatea'
-    runs-on: ubuntu-latest
-    steps:
-      - name: 🥺 Handle Ghosting
-        uses: actions/stale@v6
-        with:
-          close-issue-message: >
-            This issue has been automatically closed because we haven't received a
-            response from the original author 🙈. This automation helps keep the issue
-            tracker clean from issues that aren't actionable. Please reach out if you
-            have more information for us! 🙂
-          close-pr-message: >
-            This PR has been automatically closed because we haven't received a
-            response from the original author 🙈. This automation helps keep the issue
-            tracker clean from PRs that aren't actionable. Please reach out if you
-            have more information for us! 🙂
+    stale:
+        if: github.repository == 'eslint-community/eslint-plugin-mysticatea'
+        runs-on: ubuntu-latest
+        steps:
+            - name: 🥺 Handle Ghosting
+              uses: actions/stale@v6
+              with:
+                  close-issue-message: >
+                      This issue has been automatically closed because we haven't received a
+                      response from the original author 🙈. This automation helps keep the issue
+                      tracker clean from issues that aren't actionable. Please reach out if you
+                      have more information for us! 🙂
+                  close-pr-message: >
+                      This PR has been automatically closed because we haven't received a
+                      response from the original author 🙈. This automation helps keep the issue
+                      tracker clean from PRs that aren't actionable. Please reach out if you
+                      have more information for us! 🙂

--- a/.nycrc.yml
+++ b/.nycrc.yml
@@ -1,7 +1,7 @@
 include:
-- lib
+    - lib
 exclude:
-- lib/processors/vue.js
+    - lib/processors/vue.js
 reporter:
-- text-summary
-- lcov
+    - text-summary
+    - lcov

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+    tabWidth: 4,
+    semi: false,
+    trailingComma: "es5",
+}

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ npm install --save-dev eslint @eslint-community/eslint-plugin-mysticatea
 
 ### Requirements
 
-- Node.js `^12.22.0 || ^14.17.0 || >=16.0.0` or newer versions.
-- ESLint `^6.6.0` or newer versions.
+-   Node.js `^12.22.0 || ^14.17.0 || >=16.0.0` or newer versions.
+-   ESLint `^6.6.0` or newer versions.
 
 ## 📖 Usage
 
@@ -25,33 +25,33 @@ Write in your ESLint configurations: http://eslint.org/docs/user-guide/configuri
 
 ### Configs
 
-- `plugin:@eslint-community/mysticatea/es2022` ... Basic configuration for ES2022.
-- `plugin:@eslint-community/mysticatea/es2021` ... Basic configuration for ES2021.
-- `plugin:@eslint-community/mysticatea/es2020` ... Basic configuration for ES2020.
-- `plugin:@eslint-community/mysticatea/es2019` ... Basic configuration for ES2019.
-- `plugin:@eslint-community/mysticatea/es2018` ... Basic configuration for ES2018.
-- `plugin:@eslint-community/mysticatea/es2017` ... Basic configuration for ES2017.
-- `plugin:@eslint-community/mysticatea/es2016` ... Basic configuration for ES2016.
-- `plugin:@eslint-community/mysticatea/es2015` ... Basic configuration for ES2015.
-- `plugin:@eslint-community/mysticatea/es5` ... Basic configuration for ES5.
-- `plugin:@eslint-community/mysticatea/+modules` ... Additional configuration for ES modules.
-- `plugin:@eslint-community/mysticatea/+browser` ... Additional configuration for browser environment.
-- `plugin:@eslint-community/mysticatea/+node` ... Additional configuration for Node.js environment.
-- `plugin:@eslint-community/mysticatea/+eslint-plugin` ... Additional configuration for ESLint plugins. This includes `plugin:@eslint-community/mysticatea/+node` setting.
+-   `plugin:@eslint-community/mysticatea/es2022` ... Basic configuration for ES2022.
+-   `plugin:@eslint-community/mysticatea/es2021` ... Basic configuration for ES2021.
+-   `plugin:@eslint-community/mysticatea/es2020` ... Basic configuration for ES2020.
+-   `plugin:@eslint-community/mysticatea/es2019` ... Basic configuration for ES2019.
+-   `plugin:@eslint-community/mysticatea/es2018` ... Basic configuration for ES2018.
+-   `plugin:@eslint-community/mysticatea/es2017` ... Basic configuration for ES2017.
+-   `plugin:@eslint-community/mysticatea/es2016` ... Basic configuration for ES2016.
+-   `plugin:@eslint-community/mysticatea/es2015` ... Basic configuration for ES2015.
+-   `plugin:@eslint-community/mysticatea/es5` ... Basic configuration for ES5.
+-   `plugin:@eslint-community/mysticatea/+modules` ... Additional configuration for ES modules.
+-   `plugin:@eslint-community/mysticatea/+browser` ... Additional configuration for browser environment.
+-   `plugin:@eslint-community/mysticatea/+node` ... Additional configuration for Node.js environment.
+-   `plugin:@eslint-community/mysticatea/+eslint-plugin` ... Additional configuration for ESLint plugins. This includes `plugin:@eslint-community/mysticatea/+node` setting.
 
 #### Details
 
 The main configurations `plugin:@eslint-community/mysticatea/es*` does:
 
-- detect bug-like code by ESLint rules.
-- enforce whitespace style by Prettier.
-- handle the `.ts` files as TypeScript then check by `typescript-eslint-parser` and `eslint-plugin-typescript`.
-- handle the `.vue` files as Vue.js SFC then check by `vue-eslint-parser` and `eslint-plugin-vue`.
-- handle the files in `test`/`tests` directory as `mocha`'s test code.
-- handle the files in `scripts` directory as Node.js environment.
-- handle the `.eslintrc.js` file as a Node.js script.
-- handle the `webpack.config.js` file as a Node.js script.
-- handle the `rollup.config.js` file as an ES module.
+-   detect bug-like code by ESLint rules.
+-   enforce whitespace style by Prettier.
+-   handle the `.ts` files as TypeScript then check by `typescript-eslint-parser` and `eslint-plugin-typescript`.
+-   handle the `.vue` files as Vue.js SFC then check by `vue-eslint-parser` and `eslint-plugin-vue`.
+-   handle the files in `test`/`tests` directory as `mocha`'s test code.
+-   handle the files in `scripts` directory as Node.js environment.
+-   handle the `.eslintrc.js` file as a Node.js script.
+-   handle the `webpack.config.js` file as a Node.js script.
+-   handle the `rollup.config.js` file as an ES module.
 
 You can use combination of a main configuration and some additional configurations.
 For examples:
@@ -109,27 +109,26 @@ This plugin has some original rules and foreign rules.
 
 #### Original rules
 
-- [@eslint-community/mysticatea/arrow-parens](docs/rules/arrow-parens.md) enforces parens of argument lists (excludes too redundant parens) (fixable).
-- [@eslint-community/mysticatea/block-scoped-var](docs/rules/block-scoped-var.md) handles variables which are declared by `var` declaration as block-scoped. It disallows redeclarations, uses from outside of the scope, shadowing.
-- [@eslint-community/mysticatea/no-instanceof-array](docs/rules/no-instanceof-array.md) disallows 'instanceof' for Array (fixable).
-- [@eslint-community/mysticatea/no-instanceof-wrapper](docs/rules/no-instanceof-wrapper.md) disallows 'instanceof' for wrapper objects (fixable).
-- [@eslint-community/mysticatea/no-literal-call](docs/rules/no-literal-call.md) disallows a call of a literal.
-- [@eslint-community/mysticatea/no-this-in-static](docs/rules/no-this-in-static.md) disallows `this`/`super` in static methods.
-- [@eslint-community/mysticatea/no-use-ignored-vars](docs/rules/no-use-ignored-vars.md) disallows a use of ignored variables.
-- [@eslint-community/mysticatea/no-useless-rest-spread](docs/rules/no-useless-rest-spread.md) disallows unnecessary rest/spread operators (fixable).
-- [@eslint-community/mysticatea/prefer-for-of](docs/rules/prefer-for-of.md) requires `for-of` statements instead of `Array#forEach` or something like (fixable).
+-   [@eslint-community/mysticatea/arrow-parens](docs/rules/arrow-parens.md) enforces parens of argument lists (excludes too redundant parens) (fixable).
+-   [@eslint-community/mysticatea/block-scoped-var](docs/rules/block-scoped-var.md) handles variables which are declared by `var` declaration as block-scoped. It disallows redeclarations, uses from outside of the scope, shadowing.
+-   [@eslint-community/mysticatea/no-instanceof-array](docs/rules/no-instanceof-array.md) disallows 'instanceof' for Array (fixable).
+-   [@eslint-community/mysticatea/no-instanceof-wrapper](docs/rules/no-instanceof-wrapper.md) disallows 'instanceof' for wrapper objects (fixable).
+-   [@eslint-community/mysticatea/no-literal-call](docs/rules/no-literal-call.md) disallows a call of a literal.
+-   [@eslint-community/mysticatea/no-this-in-static](docs/rules/no-this-in-static.md) disallows `this`/`super` in static methods.
+-   [@eslint-community/mysticatea/no-use-ignored-vars](docs/rules/no-use-ignored-vars.md) disallows a use of ignored variables.
+-   [@eslint-community/mysticatea/no-useless-rest-spread](docs/rules/no-useless-rest-spread.md) disallows unnecessary rest/spread operators (fixable).
+-   [@eslint-community/mysticatea/prefer-for-of](docs/rules/prefer-for-of.md) requires `for-of` statements instead of `Array#forEach` or something like (fixable).
 
 #### Foreign rules
 
-- All `@eslint-community/mysticatea/eslint-comments/*` rules are imported from [eslint-plugin-eslint-comments](https://www.npmjs.com/package/eslint-plugin-eslint-comments).
-- All `@eslint-community/mysticatea/eslint-plugin/*` rules are imported from [eslint-plugin-eslint-plugin](https://www.npmjs.com/package/eslint-plugin-eslint-plugin).
-- All `@eslint-community/mysticatea/node/*` rules are imported from [eslint-plugin-node](https://www.npmjs.com/package/eslint-plugin-node).
-- All `@eslint-community/mysticatea/ts/*` rules are imported from [eslint-plugin-typescript](https://www.npmjs.com/package/eslint-plugin-typescript).
-- All `@eslint-community/mysticatea/vue/*` rules are imported from [eslint-plugin-vue](https://www.npmjs.com/package/eslint-plugin-vue).
-- The `@eslint-community/mysticatea/prettier` rule is imported from [eslint-plugin-prettier](https://www.npmjs.com/package/eslint-plugin-prettier).
+-   All `@eslint-community/mysticatea/eslint-comments/*` rules are imported from [eslint-plugin-eslint-comments](https://www.npmjs.com/package/eslint-plugin-eslint-comments).
+-   All `@eslint-community/mysticatea/eslint-plugin/*` rules are imported from [eslint-plugin-eslint-plugin](https://www.npmjs.com/package/eslint-plugin-eslint-plugin).
+-   All `@eslint-community/mysticatea/node/*` rules are imported from [eslint-plugin-node](https://www.npmjs.com/package/eslint-plugin-node).
+-   All `@eslint-community/mysticatea/ts/*` rules are imported from [eslint-plugin-typescript](https://www.npmjs.com/package/eslint-plugin-typescript).
+-   All `@eslint-community/mysticatea/vue/*` rules are imported from [eslint-plugin-vue](https://www.npmjs.com/package/eslint-plugin-vue).
+-   The `@eslint-community/mysticatea/prettier` rule is imported from [eslint-plugin-prettier](https://www.npmjs.com/package/eslint-plugin-prettier).
 
-> **Q:** Why don't you use those plugins directly?<br>
-> **A:** The combination with shareable configs and plugins has some problems because shareable configs were not designed to be used with plugins. @nzakas illustrated a way to use plugins as shareable configs together with other plugins in the discussion [eslint/eslint#3458](https://github.com/eslint/eslint/issues/3458#issuecomment-257161846). This is the way.
+> **Q:** Why don't you use those plugins directly?<br> > **A:** The combination with shareable configs and plugins has some problems because shareable configs were not designed to be used with plugins. @nzakas illustrated a way to use plugins as shareable configs together with other plugins in the discussion [eslint/eslint#3458](https://github.com/eslint/eslint/issues/3458#issuecomment-257161846). This is the way.
 
 ## 🚥 Semantic Versioning Policy
 
@@ -137,7 +136,7 @@ This plugin follows [semantic versioning](http://semver.org/) and [ESLint's Sema
 
 ## 📰 Changelog
 
-- [GitHub Releases](https://github.com/eslint-community/eslint-plugin-mysticatea/releases)
+-   [GitHub Releases](https://github.com/eslint-community/eslint-plugin-mysticatea/releases)
 
 ## ❤️ Contributing
 
@@ -147,8 +146,8 @@ Please use GitHub's Issues/PRs.
 
 ### Development Tools
 
-- `npm test` runs tests and measures coverage.
-- `npm run clean` removes the coverage result of `npm test` command.
-- `npm run coverage` shows the coverage result of `npm test` command.
-- `npm run update` updates auto-generated files.
-- `npm run watch` runs tests and measures coverage when source code are changed.
+-   `npm test` runs tests and measures coverage.
+-   `npm run clean` removes the coverage result of `npm test` command.
+-   `npm run coverage` shows the coverage result of `npm test` command.
+-   `npm run update` updates auto-generated files.
+-   `npm run watch` runs tests and measures coverage when source code are changed.

--- a/docs/rules/arrow-parens.md
+++ b/docs/rules/arrow-parens.md
@@ -12,39 +12,42 @@ This rule ignores arrow functions that there is a open paren before itself.
 ### The following patterns are considered warnings:
 
 ```js
-const twice = x => 2 * x;
+const twice = x => 2 * x
 ```
 
 ```js
 const obj = {
-  twich: x => 2 * x
-};
+    twich: x => 2 * x,
+}
 ```
 
 ```js
-p.then(x => 2 * x, err => console.error(err));
+p.then(
+    x => 2 * x,
+    err => console.error(err)
+)
 ```
 
 ### The following patterns are not considered warnings:
 
 ```js
-const twice = (x) => 2 * x;
-const twice = (x => 2 * x);
+const twice = (x) => 2 * x
+const twice = (x => 2 * x)
 ```
 
 ```js
 const obj = {
-  twich: (x) => 2 * x
-};
+    twich: (x) => 2 * x,
+}
 const obj2 = {
-  twich: (x => 2 * x)
-};
+    twich: (x => 2 * x),
+}
 ```
 
 ```js
-xs.map(x => 2 * x);
+xs.map(x => 2 * x)
 ```
 
 ```js
-p.then(x => 2 * x, (err) => console.error(err));
+p.then(x => 2 * x, (err) => console.error(err))
 ```

--- a/docs/rules/block-scoped-var.md
+++ b/docs/rules/block-scoped-var.md
@@ -8,54 +8,53 @@ Please turn `no-redeclare` rule off if you use this rule.
 
 This rule aims to flag below about variables which are defined with `var` declaration:
 
-- References from outside of the block which declare the variable.
-- Re-declarations in a same block.
-- Shadowing in a same function scope.
+-   References from outside of the block which declare the variable.
+-   Re-declarations in a same block.
+-   Shadowing in a same function scope.
 
 ### The following patterns are considered warnings:
 
 ```js
 {
-  var a = 0;
+    var a = 0
 }
-console.log(a); // not defined.
+console.log(a) // not defined.
 ```
 
 ```js
-for (var a = 0;;) {
-}
-console.log(a); // not defined.
+for (var a = 0; ; ) {}
+console.log(a) // not defined.
 ```
 
 ```js
-var a = 0;
-var a = 0; // already defined.
+var a = 0
+var a = 0 // already defined.
 ```
 
 ```js
-for (var a = 0;;) {
-  var a = 0; // already defined.
+for (var a = 0; ; ) {
+    var a = 0 // already defined.
 }
 ```
 
 ```js
 function foo(a) {
-  var a = 0; // already defined.
+    var a = 0 // already defined.
 }
 ```
 
 ```js
-var a = 0;
+var a = 0
 {
-  var a = 0; // already defined in the upper scope.
+    var a = 0 // already defined in the upper scope.
 }
 ```
 
 ```js
 function foo(a) {
-  if (Math.random() < 0.5) {
-    var a = 0; // already defined in the upper scope.
-  }
+    if (Math.random() < 0.5) {
+        var a = 0 // already defined in the upper scope.
+    }
 }
 ```
 
@@ -63,11 +62,10 @@ function foo(a) {
 
 ```js
 if (Math.random() < 0.5) {
-  var a = 0;
-  console.log(a);
-}
-else {
-  var a = 1;
-  console.log(a);
+    var a = 0
+    console.log(a)
+} else {
+    var a = 1
+    console.log(a)
 }
 ```

--- a/docs/rules/no-literal-call.md
+++ b/docs/rules/no-literal-call.md
@@ -1,4 +1,4 @@
-# Disallow a call of a literal  (no-literal-call)
+# Disallow a call of a literal (no-literal-call)
 
 A call of a literal is a valid syntax, but it would cause a runtime error.
 
@@ -9,8 +9,8 @@ Examples of **incorrect** code for this rule:
 ```js
 /*eslint no-literal-call: "error"*/
 
-123();
-"hello"();
+123()
+"hello"()
 ```
 
 Examples of **correct** code for this rule:
@@ -18,6 +18,6 @@ Examples of **correct** code for this rule:
 ```js
 /*eslint no-literal-call: "error"*/
 
-foo();
-(function() {})();
+foo()
+;(function () {})()
 ```

--- a/docs/rules/no-this-in-static.md
+++ b/docs/rules/no-this-in-static.md
@@ -19,13 +19,13 @@ class A {
     }
 
     static bar() {
-        this.foo()   //ERROR: Unexpected 'this'.
+        this.foo() //ERROR: Unexpected 'this'.
     }
 }
 
 class B extends A {
     static foo() {
-        super.foo()  //ERROR: Unexpected 'super'.
+        super.foo() //ERROR: Unexpected 'super'.
     }
 }
 ```

--- a/docs/rules/no-use-ignored-vars.md
+++ b/docs/rules/no-use-ignored-vars.md
@@ -13,11 +13,11 @@ Examples of **incorrect** code for this rule:
 ```js
 /*eslint no-use-ignored-vars: "error"*/
 
-let _foo = 0;
-doSomething(_foo);
+let _foo = 0
+doSomething(_foo)
 
 function foo(_a) {
-    doSomething(_a);
+    doSomething(_a)
 }
 ```
 
@@ -26,10 +26,10 @@ Examples of **correct** code for this rule:
 ```js
 /*eslint no-use-ignored-vars: "error"*/
 
-let _foo = 0;
+let _foo = 0
 
 function foo(_a) {
-    doSomething();
+    doSomething()
 }
 ```
 

--- a/docs/rules/no-useless-rest-spread.md
+++ b/docs/rules/no-useless-rest-spread.md
@@ -25,11 +25,10 @@ Examples of **correct** code for this rule:
 /*eslint no-useless-rest-spread: "error"*/
 
 let list = [a, b, c, d]
-let obj = {a, b, c, d}
+let obj = { a, b, c, d }
 foo(a, b, c)
 
-let [a, b, c, d] = list;
-let {a, b, c, d} = obj;
-function foo(a, b, c, d) {
-}
+let [a, b, c, d] = list
+let { a, b, c, d } = obj
+function foo(a, b, c, d) {}
 ```

--- a/docs/rules/prefer-for-of.md
+++ b/docs/rules/prefer-for-of.md
@@ -10,7 +10,7 @@ It's more readable than `Array#forEach` since it does not require closures.
 ```js
 /*eslint prefer-for-of: "error"*/
 
-list.forEach(value => {
+list.forEach((value) => {
     doSomething(value)
 })
 

--- a/lib/configs/+eslint-plugin.js
+++ b/lib/configs/+eslint-plugin.js
@@ -17,18 +17,19 @@ module.exports = {
                     "error",
                 "@eslint-community/mysticatea/eslint-plugin/fixer-return":
                     "error",
-                "@eslint-community/mysticatea/eslint-plugin/meta-property-ordering": [
-                    "error",
+                "@eslint-community/mysticatea/eslint-plugin/meta-property-ordering":
                     [
-                        "deprecated",
-                        "docs",
-                        "fixable",
-                        "messages",
-                        "replacedBy",
-                        "schema",
-                        "type",
+                        "error",
+                        [
+                            "deprecated",
+                            "docs",
+                            "fixable",
+                            "messages",
+                            "replacedBy",
+                            "schema",
+                            "type",
+                        ],
                     ],
-                ],
                 "@eslint-community/mysticatea/eslint-plugin/no-deprecated-context-methods":
                     "error",
                 "@eslint-community/mysticatea/eslint-plugin/no-deprecated-report-api":
@@ -49,36 +50,33 @@ module.exports = {
                     "error",
                 "@eslint-community/mysticatea/eslint-plugin/prefer-replace-text":
                     "error",
-                "@eslint-community/mysticatea/eslint-plugin/report-message-format": [
-                    "error",
-                    "[^a-z'\"{].*\\.$",
-                ],
+                "@eslint-community/mysticatea/eslint-plugin/report-message-format":
+                    ["error", "[^a-z'\"{].*\\.$"],
                 "@eslint-community/mysticatea/eslint-plugin/require-meta-docs-description":
                     "error",
-                "@eslint-community/mysticatea/eslint-plugin/require-meta-docs-url": [
-                    "error",
-                    { pattern: rulesDocumentUrl },
-                ],
+                "@eslint-community/mysticatea/eslint-plugin/require-meta-docs-url":
+                    ["error", { pattern: rulesDocumentUrl }],
                 "@eslint-community/mysticatea/eslint-plugin/require-meta-fixable":
                     "error",
                 "@eslint-community/mysticatea/eslint-plugin/require-meta-schema":
                     "error",
                 "@eslint-community/mysticatea/eslint-plugin/require-meta-type":
                     "error",
-                "@eslint-community/mysticatea/eslint-plugin/test-case-property-ordering": [
-                    "error",
+                "@eslint-community/mysticatea/eslint-plugin/test-case-property-ordering":
                     [
-                        "filename",
-                        "code",
-                        "output",
-                        "options",
-                        "parser",
-                        "parserOptions",
-                        "globals",
-                        "env",
-                        "errors",
+                        "error",
+                        [
+                            "filename",
+                            "code",
+                            "output",
+                            "options",
+                            "parser",
+                            "parserOptions",
+                            "globals",
+                            "env",
+                            "errors",
+                        ],
                     ],
-                ],
                 "@eslint-community/mysticatea/eslint-plugin/test-case-shorthand-strings":
                     "error",
             },

--- a/lib/configs/_base.js
+++ b/lib/configs/_base.js
@@ -406,9 +406,8 @@ module.exports = {
         "@eslint-community/mysticatea/prettier": [
             "error",
             {
-                tabWidth: 4,
                 semi: false,
-                trailingComma: "es5",
+                tabWidth: 4,
             },
             {
                 usePrettierrc: false,

--- a/lib/configs/_override-2017.js
+++ b/lib/configs/_override-2017.js
@@ -16,8 +16,8 @@ module.exports = {
         "@eslint-community/mysticatea/prettier": [
             "error",
             {
-                tabWidth: 4,
                 semi: false,
+                tabWidth: 4,
                 trailingComma: "all",
             },
             {

--- a/lib/configs/_override-ts.js
+++ b/lib/configs/_override-ts.js
@@ -128,10 +128,10 @@ module.exports = {
                 "@eslint-community/mysticatea/prettier": [
                     "error",
                     {
-                        tabWidth: 4,
-                        semi: false,
-                        trailingComma: "all",
                         parser: "typescript",
+                        semi: false,
+                        tabWidth: 4,
+                        trailingComma: "all",
                     },
                     {
                         usePrettierrc: false,

--- a/lib/configs/_override-vue.js
+++ b/lib/configs/_override-vue.js
@@ -155,20 +155,19 @@ module.exports = {
                 "@eslint-community/mysticatea/vue/html-quotes": "error",
                 "@eslint-community/mysticatea/vue/order-in-components": "error",
                 "@eslint-community/mysticatea/vue/this-in-template": "error",
-                "@eslint-community/mysticatea/vue/html-closing-bracket-newline": [
-                    "error",
-                    {
-                        singleline: "never",
-                        multiline: "always",
-                    },
-                ],
+                "@eslint-community/mysticatea/vue/html-closing-bracket-newline":
+                    [
+                        "error",
+                        {
+                            singleline: "never",
+                            multiline: "always",
+                        },
+                    ],
                 "@eslint-community/mysticatea/vue/html-closing-bracket-spacing":
                     "error",
                 "@eslint-community/mysticatea/vue/prop-name-casing": "error",
-                "@eslint-community/mysticatea/vue/component-name-in-template-casing": [
-                    "error",
-                    "kebab-case",
-                ],
+                "@eslint-community/mysticatea/vue/component-name-in-template-casing":
+                    ["error", "kebab-case"],
                 "@eslint-community/mysticatea/vue/multiline-html-element-content-newline":
                     "error",
                 "@eslint-community/mysticatea/vue/singleline-html-element-content-newline":

--- a/lib/processors/vue.js
+++ b/lib/processors/vue.js
@@ -22,7 +22,7 @@ module.exports = {
         }
 
         // Filter messages which are in disabled area.
-        return messages[0].filter(message => {
+        return messages[0].filter((message) => {
             if (
                 message.ruleId ===
                 "@eslint-community/mysticatea/vue/comment-directive"

--- a/lib/rules/arrow-parens.js
+++ b/lib/rules/arrow-parens.js
@@ -30,8 +30,7 @@ module.exports = {
             description: "enforce the parentheses style of arrow functions.",
             category: "Stylistic Issues",
             recommended: false,
-            url:
-                "https://github.com/eslint-community/eslint-plugin-mysticatea/blob/HEAD/docs/rules/arrow-parens.md",
+            url: "https://github.com/eslint-community/eslint-plugin-mysticatea/blob/HEAD/docs/rules/arrow-parens.md",
         },
         fixable: "code",
         schema: [],

--- a/lib/rules/block-scoped-var.js
+++ b/lib/rules/block-scoped-var.js
@@ -9,8 +9,10 @@
 // Helpers
 //------------------------------------------------------------------------------
 
-const scopeNodeType = /^(?:(?:Block|Switch|For(?:In|Of)?)Statement|CatchClause|Program)$/u
-const containerNodeType = /^(?:For(?:In|Of)?Statement|(?:Arrow)?Function(?:Declaration|Expression))$/u
+const scopeNodeType =
+    /^(?:(?:Block|Switch|For(?:In|Of)?)Statement|CatchClause|Program)$/u
+const containerNodeType =
+    /^(?:For(?:In|Of)?Statement|(?:Arrow)?Function(?:Declaration|Expression))$/u
 
 /**
  * Checks whether or not a given definition should be skipped.
@@ -196,8 +198,7 @@ module.exports = {
             description: "disallow illegal usage of variables as block-scoped.",
             category: "Possible Errors",
             recommended: false,
-            url:
-                "https://github.com/eslint-community/eslint-plugin-mysticatea/blob/HEAD/docs/rules/block-scoped-var.md",
+            url: "https://github.com/eslint-community/eslint-plugin-mysticatea/blob/HEAD/docs/rules/block-scoped-var.md",
         },
         fixable: null,
         schema: [],

--- a/lib/rules/no-instanceof-array.js
+++ b/lib/rules/no-instanceof-array.js
@@ -14,8 +14,7 @@ module.exports = {
         docs: {
             description: "disallow 'instanceof' for Array",
             category: "Best Practices",
-            url:
-                "https://github.com/eslint-community/eslint-plugin-mysticatea/blob/HEAD/docs/rules/no-instanceof-array.md",
+            url: "https://github.com/eslint-community/eslint-plugin-mysticatea/blob/HEAD/docs/rules/no-instanceof-array.md",
         },
         fixable: "code",
         schema: [],
@@ -64,7 +63,7 @@ module.exports = {
                         loc: node.loc,
                         message:
                             "Unexpected 'instanceof' operator. Use 'Array.isArray' instead.",
-                        fix: fixer =>
+                        fix: (fixer) =>
                             fixer.replaceText(
                                 node,
                                 `Array.isArray(${sourceCode.getText(

--- a/lib/rules/no-instanceof-wrapper.js
+++ b/lib/rules/no-instanceof-wrapper.js
@@ -14,8 +14,7 @@ module.exports = {
         docs: {
             description: "disallow 'instanceof' for wrapper objects",
             category: "Best Practices",
-            url:
-                "https://github.com/eslint-community/eslint-plugin-mysticatea/blob/HEAD/docs/rules/no-instanceof-wrapper.md",
+            url: "https://github.com/eslint-community/eslint-plugin-mysticatea/blob/HEAD/docs/rules/no-instanceof-wrapper.md",
         },
         fixable: "code",
         schema: [],
@@ -76,7 +75,7 @@ module.exports = {
                             message:
                                 "Unexpected 'instanceof' operator. Use 'typeof x === \"{{typeName}}\"' instead.",
                             data: { typeName },
-                            fix: fixer =>
+                            fix: (fixer) =>
                                 fixer.replaceText(
                                     node,
                                     `typeof ${sourceCode.getText(

--- a/lib/rules/no-literal-call.js
+++ b/lib/rules/no-literal-call.js
@@ -9,7 +9,8 @@
 //------------------------------------------------------------------------------
 
 const LITERAL_TYPE = /^(?:(?:Array|Object)Expression|(?:Template)?Literal)$/u
-const LITERAL_AND_CLASS_TYPE = /^(?:(?:Array|Class|Object)Expression|(?:Template)?Literal)$/u
+const LITERAL_AND_CLASS_TYPE =
+    /^(?:(?:Array|Class|Object)Expression|(?:Template)?Literal)$/u
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -21,8 +22,7 @@ module.exports = {
             description: "disallow a call of a literal.",
             category: "Possible Errors",
             recommended: false,
-            url:
-                "https://github.com/eslint-community/eslint-plugin-mysticatea/blob/HEAD/docs/rules/no-literal-call.md",
+            url: "https://github.com/eslint-community/eslint-plugin-mysticatea/blob/HEAD/docs/rules/no-literal-call.md",
         },
         fixable: null,
         schema: [],

--- a/lib/rules/no-this-in-static.js
+++ b/lib/rules/no-this-in-static.js
@@ -14,8 +14,7 @@ module.exports = {
         docs: {
             description: "disallow `this`/`super` in static methods",
             category: "Best Practices",
-            url:
-                "https://github.com/eslint-community/eslint-plugin-mysticatea/blob/HEAD/docs/rules/no-this-in-static.md",
+            url: "https://github.com/eslint-community/eslint-plugin-mysticatea/blob/HEAD/docs/rules/no-this-in-static.md",
         },
         fixable: null,
         schema: [],

--- a/lib/rules/no-use-ignored-vars.js
+++ b/lib/rules/no-use-ignored-vars.js
@@ -20,8 +20,7 @@ module.exports = {
             description: "disallow a use of ignored variables.",
             category: "Stylistic Issues",
             recommended: false,
-            url:
-                "https://github.com/eslint-community/eslint-plugin-mysticatea/blob/HEAD/docs/rules/no-use-ignored-vars.md",
+            url: "https://github.com/eslint-community/eslint-plugin-mysticatea/blob/HEAD/docs/rules/no-use-ignored-vars.md",
         },
         fixable: null,
         schema: [{ type: "string" }],

--- a/lib/rules/no-useless-rest-spread.js
+++ b/lib/rules/no-useless-rest-spread.js
@@ -8,7 +8,8 @@
 // Helpers
 //------------------------------------------------------------------------------
 
-const FUNC_TYPE = /^(?:FunctionDeclaration|(?:New|Call|(?:Arrow)?Function)Expression)$/u
+const FUNC_TYPE =
+    /^(?:FunctionDeclaration|(?:New|Call|(?:Arrow)?Function)Expression)$/u
 const PROPERTY_PATTERN = /^(?:Experimental)?(Rest|Spread)Property$/u
 
 /**
@@ -56,7 +57,7 @@ function getLastElementToken(sourceCode, node) {
  * @returns {function} A fixer function.
  */
 function defineFixer(sourceCode, node) {
-    return fixer => {
+    return (fixer) => {
         const child = node.argument
 
         // If the inner array includes holes, do nothing.
@@ -97,8 +98,7 @@ module.exports = {
             description: "disallow unnecessary spread operators.",
             category: "Best Practices",
             recommended: false,
-            url:
-                "https://github.com/eslint-community/eslint-plugin-mysticatea/blob/HEAD/docs/rules/no-useless-rest-spread.md",
+            url: "https://github.com/eslint-community/eslint-plugin-mysticatea/blob/HEAD/docs/rules/no-useless-rest-spread.md",
         },
         fixable: "code",
         schema: [],
@@ -116,7 +116,7 @@ module.exports = {
         function verify(node) {
             const nodeType = node.type.replace(
                 PROPERTY_PATTERN,
-                t => `${t}Element`
+                (t) => `${t}Element`
             )
             const parentType = node.parent.type
             const argumentType = node.argument.type
@@ -131,11 +131,11 @@ module.exports = {
                     nodeType === "RestElement" && argumentType !== parentType
                 const type1 = nodeType === "RestElement" ? "rest" : "spread"
                 const type2 =
-                    /*eslint-disable @eslint-community/mysticatea/prettier */
+                    /* eslint-disable @eslint-community/mysticatea/prettier */
                     isRestParameter ? "parameter" :
                     isArray ? "element" :
                     /* otherwise */ "property"
-                    /*eslint-enable @eslint-community/mysticatea/prettier */
+                    /* eslint-enable @eslint-community/mysticatea/prettier */
 
                 context.report({
                     node,

--- a/lib/rules/prefer-for-of.js
+++ b/lib/rules/prefer-for-of.js
@@ -115,7 +115,7 @@ function isTraversingArray(node) {
     let indexDecl = null
     let lengthDecl = null
 
-    /*eslint-disable @eslint-community/mysticatea/prettier */
+    /* eslint-disable @eslint-community/mysticatea/prettier */
     return (
         init != null &&
         init.type === "VariableDeclaration" &&
@@ -186,7 +186,7 @@ function isTraversingArray(node) {
             )
         )
     )
-    /*eslint-enable @eslint-community/mysticatea/prettier */
+    /* eslint-enable @eslint-community/mysticatea/prettier */
 }
 
 /**
@@ -243,7 +243,7 @@ function isIndexVarOnlyUsedToGetArrayElements(context, node) {
     const arrayText = getArrayTextOfForStatement(sourceCode, node)
     const indexVar = context.getDeclaredVariables(node.init)[0]
 
-    return indexVar.references.every(reference => {
+    return indexVar.references.every((reference) => {
         const id = reference.identifier
 
         return (
@@ -273,7 +273,8 @@ function isLengthVarOnlyUsedToTest(context, node) {
     const lengthVar = context.getDeclaredVariables(node.init.declarations[1])[0]
 
     return lengthVar.references.every(
-        reference => reference.init || contains(node.test, reference.identifier)
+        (reference) =>
+            reference.init || contains(node.test, reference.identifier)
     )
 }
 
@@ -497,8 +498,7 @@ module.exports = {
             description: "requires for-of statements instead of Array#forEach",
             category: "Best Practices",
             recommended: false,
-            url:
-                "https://github.com/eslint-community/eslint-plugin-mysticatea/blob/HEAD/docs/rules/prefer-for-of.md",
+            url: "https://github.com/eslint-community/eslint-plugin-mysticatea/blob/HEAD/docs/rules/prefer-for-of.md",
         },
         fixable: "code",
         schema: [],
@@ -580,7 +580,7 @@ module.exports = {
                 if (
                     thisFuncInfo != null &&
                     thisFuncInfo.isTarget &&
-                    !thisFuncInfo.returnNodes.some(returnNode =>
+                    !thisFuncInfo.returnNodes.some((returnNode) =>
                         contains(returnNode, node)
                     )
                 ) {

--- a/package.json
+++ b/package.json
@@ -1,72 +1,73 @@
 {
-  "name": "@eslint-community/eslint-plugin-mysticatea",
-  "version": "0.0.0-semantically-released",
-  "description": "Additional ESLint rules.",
-  "engines": {
-    "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-  },
-  "main": "index.js",
-  "files": [
-    "lib"
-  ],
-  "peerDependencies": {
-    "eslint": ">=6.6.0"
-  },
-  "dependencies": {
-    "@typescript-eslint/eslint-plugin": "^2.34.0",
-    "@typescript-eslint/parser": "^2.34.0",
-    "eslint-plugin-eslint-comments": "^3.2.0",
-    "eslint-plugin-eslint-plugin": "^2.3.0",
-    "eslint-plugin-node": "^10.0.0",
-    "eslint-plugin-prettier": "^3.4.1",
-    "eslint-plugin-vue": "^6.2.2",
-    "prettier": "^2.7.1",
-    "vue-eslint-parser": "^7.11.0"
-  },
-  "devDependencies": {
-    "@eslint-community/eslint-plugin-mysticatea": "file:.",
-    "eslint": "^6.8.0",
-    "fs-extra": "^8.1.0",
-    "globals": "^13.17.0",
-    "mocha": "^9.2.2",
-    "npm-run-all": "^4.1.5",
-    "nyc": "^15.1.0",
-    "opener": "^1.5.2",
-    "rimraf": "^3.0.2",
-    "typescript": "^4.8.4"
-  },
-  "scripts": {
-    "clean": "rimraf .nyc_output coverage",
-    "coverage": "opener coverage/lcov-report/index.html",
-    "lint": "eslint lib scripts tests",
-    "test": "nyc mocha \"tests/lib/**/*.js\" --reporter dot",
-    "update": "node scripts/generate-browser-globals && node scripts/generate-configs && node scripts/generate-rules",
-    "preversion": "run-s clean update test",
-    "version": "eslint lib/rules --fix && git add lib",
-    "postversion": "git push && git push --tags",
-    "watch": "mocha \"tests/lib/**/*.js\" --reporter dot --watch --growl"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/eslint-community/eslint-plugin-mysticatea"
-  },
-  "keywords": [
-    "eslint",
-    "eslintplugin",
-    "block",
-    "scope",
-    "instanceof",
-    "isArray",
-    "static",
-    "this",
-    "rest",
-    "spread",
-    "ignore"
-  ],
-  "author": "Toru Nagashima",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/eslint-community/eslint-plugin-mysticatea/issues"
-  },
-  "homepage": "https://github.com/eslint-community/eslint-plugin-mysticatea#readme"
+    "name": "@eslint-community/eslint-plugin-mysticatea",
+    "version": "0.0.0-semantically-released",
+    "description": "Additional ESLint rules.",
+    "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+    },
+    "main": "index.js",
+    "files": [
+        "lib"
+    ],
+    "peerDependencies": {
+        "eslint": ">=6.6.0"
+    },
+    "dependencies": {
+        "@typescript-eslint/eslint-plugin": "^2.34.0",
+        "@typescript-eslint/parser": "^2.34.0",
+        "eslint-plugin-eslint-comments": "^3.2.0",
+        "eslint-plugin-eslint-plugin": "^2.3.0",
+        "eslint-plugin-node": "^10.0.0",
+        "eslint-plugin-prettier": "^3.4.1",
+        "eslint-plugin-vue": "^6.2.2",
+        "prettier": "^2.7.1",
+        "vue-eslint-parser": "^7.11.0"
+    },
+    "devDependencies": {
+        "@eslint-community/eslint-plugin-mysticatea": "file:.",
+        "eslint": "^6.8.0",
+        "fs-extra": "^8.1.0",
+        "globals": "^13.17.0",
+        "mocha": "^9.2.2",
+        "npm-run-all": "^4.1.5",
+        "nyc": "^15.1.0",
+        "opener": "^1.5.2",
+        "rimraf": "^3.0.2",
+        "typescript": "^4.8.4"
+    },
+    "scripts": {
+        "clean": "rimraf .nyc_output coverage",
+        "coverage": "opener coverage/lcov-report/index.html",
+        "format": "prettier -w .",
+        "lint": "eslint lib scripts tests",
+        "test": "nyc mocha \"tests/lib/**/*.js\" --reporter dot",
+        "update": "node scripts/generate-browser-globals && node scripts/generate-configs && node scripts/generate-rules",
+        "preversion": "run-s clean update test",
+        "version": "eslint lib/rules --fix && git add lib",
+        "postversion": "git push && git push --tags",
+        "watch": "mocha \"tests/lib/**/*.js\" --reporter dot --watch --growl"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/eslint-community/eslint-plugin-mysticatea"
+    },
+    "keywords": [
+        "eslint",
+        "eslintplugin",
+        "block",
+        "scope",
+        "instanceof",
+        "isArray",
+        "static",
+        "this",
+        "rest",
+        "spread",
+        "ignore"
+    ],
+    "author": "Toru Nagashima",
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/eslint-community/eslint-plugin-mysticatea/issues"
+    },
+    "homepage": "https://github.com/eslint-community/eslint-plugin-mysticatea#readme"
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "eslint-plugin-node": "^10.0.0",
     "eslint-plugin-prettier": "^3.4.1",
     "eslint-plugin-vue": "^6.2.2",
-    "prettier": "^1.19.1",
+    "prettier": "^2.7.1",
     "vue-eslint-parser": "^7.11.0"
   },
   "devDependencies": {

--- a/scripts/generate-configs.js
+++ b/scripts/generate-configs.js
@@ -20,9 +20,9 @@ fs.writeFileSync(
 module.exports = {
 ${fs
     .readdirSync(path.resolve(__dirname, "../lib/configs"))
-    .map(fileName => path.basename(fileName, ".js"))
-    .filter(id => !id.startsWith("_"))
-    .map(id => `    "${id}": require("./configs/${id}"),`)
+    .map((fileName) => path.basename(fileName, ".js"))
+    .filter((id) => !id.startsWith("_"))
+    .map((id) => `    "${id}": require("./configs/${id}"),`)
     .join("\n")}
 }
 `

--- a/scripts/generate-rules.js
+++ b/scripts/generate-rules.js
@@ -20,14 +20,14 @@ fs.writeFileSync(
 module.exports = Object.assign(
 ${fs
     .readdirSync(path.resolve(__dirname, "../lib/foreign-rules"))
-    .map(fileName => path.basename(fileName, ".js"))
-    .map(id => `    require("./foreign-rules/${id}"),`)
+    .map((fileName) => path.basename(fileName, ".js"))
+    .map((id) => `    require("./foreign-rules/${id}"),`)
     .join("\n")}
     {
 ${fs
     .readdirSync(path.resolve(__dirname, "../lib/rules"))
-    .map(fileName => path.basename(fileName, ".js"))
-    .map(id => `        "${id}": require("./rules/${id}"),`)
+    .map((fileName) => path.basename(fileName, ".js"))
+    .map((id) => `        "${id}": require("./rules/${id}"),`)
     .join("\n")}
     }
 )

--- a/tests/lib/configs/_rules.js
+++ b/tests/lib/configs/_rules.js
@@ -15,7 +15,7 @@ const {
 
 const coreRules = new Linter().getRules()
 const pluginRules = new Map(
-    Object.keys(PluginRulesIndex).map(key => [
+    Object.keys(PluginRulesIndex).map((key) => [
         `@eslint-community/mysticatea/${key}`,
         PluginRulesIndex[key],
     ])
@@ -41,12 +41,12 @@ module.exports = {
      * @returns {void}
      */
     validateConfig(config, source) {
-        Validator.validate(config, source, ruleId => allRules.get(ruleId))
+        Validator.validate(config, source, (ruleId) => allRules.get(ruleId))
 
         /* istanbul ignore next */
         for (const ruleId of [].concat(
             Object.keys(config.rules || {}),
-            ...(config.overrides || []).map(c => Object.keys(c.rules || {}))
+            ...(config.overrides || []).map((c) => Object.keys(c.rules || {}))
         )) {
             const rule = allRules.get(ruleId)
             if (rule == null) {
@@ -76,7 +76,7 @@ module.exports = {
      */
     getCoreRuleNames() {
         return Array.from(coreRules.keys()).filter(
-            ruleId =>
+            (ruleId) =>
                 !deprecatedRuleNames.has(ruleId) &&
                 !removedRuleNames.has(ruleId)
         )
@@ -89,14 +89,14 @@ module.exports = {
      */
     getPluginRuleNames(pluginName) {
         return Object.keys(PluginRulesIndex)
-            .filter(ruleId =>
+            .filter((ruleId) =>
                 pluginName === "@eslint-community/mysticatea"
                     ? !ruleId.includes("/")
                     : ruleId.startsWith(`${pluginName}/`)
             )
-            .map(ruleId => `@eslint-community/mysticatea/${ruleId}`)
+            .map((ruleId) => `@eslint-community/mysticatea/${ruleId}`)
             .filter(
-                ruleId =>
+                (ruleId) =>
                     !deprecatedRuleNames.has(ruleId) &&
                     !removedRuleNames.has(ruleId)
             )

--- a/tests/lib/rules/block-scoped-var.js
+++ b/tests/lib/rules/block-scoped-var.js
@@ -14,8 +14,7 @@ new RuleTester().run("block-scoped-var", rule, {
         "if (true) { var a; a; } else if (true) { var a; a; } else { var a; a; }",
         "while (true) { var a; a; } do { var a; a; } while (true);",
         {
-            code:
-                "for (var a = 0; a; a) { a; var b; b; } for (var a in []) { a; var b; b; } for (var a of []) { a; var b; b; }",
+            code: "for (var a = 0; a; a) { a; var b; b; } for (var a in []) { a; var b; b; } for (var a of []) { a; var b; b; }",
             env: { es6: true },
         },
         "switch (0) { case 0: var a; a; case 1: a; default: a; } { var a; a; }",
@@ -85,8 +84,7 @@ new RuleTester().run("block-scoped-var", rule, {
             ],
         },
         {
-            code:
-                "{ var {x: [a = 0]} = {x: [1]}; a; } { var a; ({x: [a = 0]} = {x: [1]}); }",
+            code: "{ var {x: [a = 0]} = {x: [1]}; a; } { var a; ({x: [a = 0]} = {x: [1]}); }",
             env: { es6: true },
             errors: [
                 {

--- a/tests/lib/rules/prefer-for-of.js
+++ b/tests/lib/rules/prefer-for-of.js
@@ -37,10 +37,8 @@ tester.run("prefer-for-of", rule, {
     ],
     invalid: [
         {
-            code:
-                "list.forEach(function(value) { return; function foo() { return } });",
-            output:
-                "for (let value of list) { continue; function foo() { return } }",
+            code: "list.forEach(function(value) { return; function foo() { return } });",
+            output: "for (let value of list) { continue; function foo() { return } }",
             errors: ["Expected for-of statement."],
         },
         {
@@ -62,8 +60,7 @@ tester.run("prefer-for-of", rule, {
             errors: ["Expected for-of statement."],
         },
         {
-            code:
-                "list.forEach(function(value) { return; let obj; this.a }, obj);",
+            code: "list.forEach(function(value) { return; let obj; this.a }, obj);",
             output: null,
             globals: { list: false, obj: false },
             errors: ["Expected for-of statement."],
@@ -87,8 +84,7 @@ tester.run("prefer-for-of", rule, {
             errors: ["Expected for-of statement."],
         },
         {
-            code:
-                "list.forEach(function(value) { return; foo(a => this[a]) });",
+            code: "list.forEach(function(value) { return; foo(a => this[a]) });",
             output: "for (let value of list) { continue; foo(a => list[a]) }",
             globals: { list: false, obj: false },
             errors: ["Expected for-of statement."],
@@ -126,8 +122,7 @@ tester.run("prefer-for-of", rule, {
             errors: ["Expected for-of statement."],
         },
         {
-            code:
-                "list.filter(p)\n    .map(t)\n    .forEach(value => { return });",
+            code: "list.filter(p)\n    .map(t)\n    .forEach(value => { return });",
             output: null,
             errors: ["Expected for-of statement."],
         },
@@ -137,38 +132,32 @@ tester.run("prefer-for-of", rule, {
             errors: ["Expected for-of statement."],
         },
         {
-            code:
-                "function wrap() { for (let i = 0; i < list.length; ++i) { return } }",
+            code: "function wrap() { for (let i = 0; i < list.length; ++i) { return } }",
             output: null,
             errors: ["Expected for-of statement."],
         },
         {
-            code:
-                "function wrap() { for (let i = 0; i < list.length; ++i) { const value = list[i]; return } }",
+            code: "function wrap() { for (let i = 0; i < list.length; ++i) { const value = list[i]; return } }",
             output: "function wrap() { for (let value of list) { return } }",
             errors: ["Expected for-of statement."],
         },
         {
-            code:
-                "function wrap() { for (let i = 0; i < list.length; i++) { const value = list[i]; return } }",
+            code: "function wrap() { for (let i = 0; i < list.length; i++) { const value = list[i]; return } }",
             output: "function wrap() { for (let value of list) { return } }",
             errors: ["Expected for-of statement."],
         },
         {
-            code:
-                "function wrap() { for (let i = 0; i < list.length; i += 1) { const value = list[i]; return } }",
+            code: "function wrap() { for (let i = 0; i < list.length; i += 1) { const value = list[i]; return } }",
             output: "function wrap() { for (let value of list) { return } }",
             errors: ["Expected for-of statement."],
         },
         {
-            code:
-                "for (let i = 0, end = list.length; i < end;i = 1 + i) { const value = list[i]; }",
+            code: "for (let i = 0, end = list.length; i < end;i = 1 + i) { const value = list[i]; }",
             output: "for (let value of list) { }",
             errors: ["Expected for-of statement."],
         },
         {
-            code:
-                "for (let i = 0, length = list.length; i < length; i = i + 1) { const value = list[i]; }",
+            code: "for (let i = 0, length = list.length; i < length; i = i + 1) { const value = list[i]; }",
             output: "for (let value of list) { }",
             errors: ["Expected for-of statement."],
         },


### PR DESCRIPTION
Re-submission of https://github.com/mysticatea/eslint-plugin/pull/39

> This impacts the `@mysticatea/prettier` rule
> 
> I've also fixed all ESLint errors this caused & ran Prettier on the full codebase

---

BREAKING CHANGE: `es5`, `es2015`, `es2016`, `es2017`, `es2018`, `es2019`, `es2020`, `es2021` & `es2022` configs will now report for their changed default values. For more info check their [release notes](https://prettier.io/blog/2020/03/21/2.0.0.html#breaking-changes)