### PR TITLE
feat: update `@typescript-eslint/*` + update configs

### DIFF
--- a/lib/configs/_override-ts.js
+++ b/lib/configs/_override-ts.js
@@ -21,10 +21,20 @@ module.exports = {
                 "@eslint-community/mysticatea/ts/array-type": "error",
                 "@eslint-community/mysticatea/ts/await-thenable": "error",
                 "@eslint-community/mysticatea/ts/ban-ts-comment": "error",
+                "@eslint-community/mysticatea/ts/ban-tslint-comment": "error",
                 "@eslint-community/mysticatea/ts/class-literal-property-style":
                     "error",
+                "@eslint-community/mysticatea/ts/comma-dangle": "error",
                 "@eslint-community/mysticatea/ts/comma-spacing": "error",
+                "@eslint-community/mysticatea/ts/consistent-generic-constructors":
+                    "error",
+                "@eslint-community/mysticatea/ts/consistent-indexed-object-style":
+                    "error",
                 "@eslint-community/mysticatea/ts/consistent-type-assertions":
+                    "error",
+                "@eslint-community/mysticatea/ts/consistent-type-exports":
+                    "error",
+                "@eslint-community/mysticatea/ts/consistent-type-imports":
                     "error",
                 "@eslint-community/mysticatea/ts/default-param-last": "error",
                 "@eslint-community/mysticatea/ts/dot-notation": "error",
@@ -41,7 +51,13 @@ module.exports = {
                 "@eslint-community/mysticatea/ts/naming-convention": "error",
                 "@eslint-community/mysticatea/ts/no-array-constructor": "error",
                 "@eslint-community/mysticatea/ts/no-base-to-string": "error",
+                "@eslint-community/mysticatea/ts/no-confusing-non-null-assertion":
+                    "error",
+                "@eslint-community/mysticatea/ts/no-confusing-void-expression":
+                    "error",
                 "@eslint-community/mysticatea/ts/no-dupe-class-members":
+                    "error",
+                "@eslint-community/mysticatea/ts/no-duplicate-enum-values":
                     "error",
                 "@eslint-community/mysticatea/ts/no-dynamic-delete": "error",
                 "@eslint-community/mysticatea/ts/no-empty-interface": "error",
@@ -55,13 +71,23 @@ module.exports = {
                 "@eslint-community/mysticatea/ts/no-inferrable-types": "error",
                 "@eslint-community/mysticatea/ts/no-invalid-this": "error",
                 "@eslint-community/mysticatea/ts/no-invalid-void-type": "error",
+                "@eslint-community/mysticatea/ts/no-loss-of-precision": "error",
+                "@eslint-community/mysticatea/ts/no-loop-func": "error",
+                "@eslint-community/mysticatea/ts/no-meaningless-void-operator":
+                    "error",
                 "@eslint-community/mysticatea/ts/no-misused-new": "error",
                 "@eslint-community/mysticatea/ts/no-misused-promises": "error",
+                "@eslint-community/mysticatea/ts/no-non-null-asserted-nullish-coalescing":
+                    "error",
                 "@eslint-community/mysticatea/ts/no-non-null-asserted-optional-chain":
                     "error",
-                "@eslint-community/mysticatea/ts/no-parameter-properties":
+                "@eslint-community/mysticatea/ts/no-redundant-type-constituents":
                     "error",
+                "@eslint-community/mysticatea/ts/no-redeclare": "error",
                 "@eslint-community/mysticatea/ts/no-require-imports": "error",
+                "@eslint-community/mysticatea/ts/no-restricted-imports":
+                    "error",
+                "@eslint-community/mysticatea/ts/no-shadow": "error",
                 "@eslint-community/mysticatea/ts/no-this-alias": [
                     "error",
                     { allowDestructuring: true },
@@ -75,6 +101,9 @@ module.exports = {
                     "error",
                 "@eslint-community/mysticatea/ts/no-unnecessary-type-assertion":
                     "error",
+                "@eslint-community/mysticatea/ts/no-unnecessary-type-constraint":
+                    "error",
+                "@eslint-community/mysticatea/ts/no-unsafe-argument": "error",
                 "@eslint-community/mysticatea/ts/no-unsafe-assignment": "error",
                 "@eslint-community/mysticatea/ts/no-unsafe-call": "error",
                 "@eslint-community/mysticatea/ts/no-unsafe-member-access":
@@ -82,13 +111,23 @@ module.exports = {
                 "@eslint-community/mysticatea/ts/no-unsafe-return": "error",
                 "@eslint-community/mysticatea/ts/no-unused-expressions":
                     "error",
-                "@eslint-community/mysticatea/ts/no-unused-vars-experimental":
+                "@eslint-community/mysticatea/ts/no-useless-empty-export":
                     "error",
                 "@eslint-community/mysticatea/ts/no-var-requires": "error",
+                "@eslint-community/mysticatea/ts/non-nullable-type-assertion-style":
+                    "error",
+                "@eslint-community/mysticatea/ts/object-curly-spacing": "error",
+                "@eslint-community/mysticatea/ts/padding-line-between-statements":
+                    "error",
+                "@eslint-community/mysticatea/ts/parameter-properties": "error",
                 "@eslint-community/mysticatea/ts/prefer-as-const": "error",
+                "@eslint-community/mysticatea/ts/prefer-enum-initializers":
+                    "error",
                 // https://github.com/typescript-eslint/typescript-eslint/issues/454
                 "@eslint-community/mysticatea/ts/prefer-function-type": "off",
                 "@eslint-community/mysticatea/ts/prefer-includes": "error",
+                "@eslint-community/mysticatea/ts/prefer-literal-enum-member":
+                    "error",
                 "@eslint-community/mysticatea/ts/prefer-namespace-keyword":
                     "error",
                 "@eslint-community/mysticatea/ts/prefer-nullish-coalescing":
@@ -102,6 +141,8 @@ module.exports = {
                 "@eslint-community/mysticatea/ts/prefer-reduce-type-parameter":
                     "off",
                 "@eslint-community/mysticatea/ts/prefer-regexp-exec": "error",
+                "@eslint-community/mysticatea/ts/prefer-return-this-type":
+                    "off",
                 "@eslint-community/mysticatea/ts/prefer-string-starts-ends-with":
                     "error",
                 "@eslint-community/mysticatea/ts/prefer-ts-expect-error": "off",
@@ -112,8 +153,11 @@ module.exports = {
                 "@eslint-community/mysticatea/ts/restrict-template-expressions":
                     "error",
                 "@eslint-community/mysticatea/ts/return-await": "error",
+                "@eslint-community/mysticatea/ts/sort-type-union-intersection-members":
+                    "error",
                 "@eslint-community/mysticatea/ts/space-before-function-paren":
                     "error",
+                "@eslint-community/mysticatea/ts/space-infix-ops": "error",
                 "@eslint-community/mysticatea/ts/switch-exhaustiveness-check":
                     "error",
                 "@eslint-community/mysticatea/ts/triple-slash-reference":
@@ -183,6 +227,7 @@ module.exports = {
                 "@eslint-community/mysticatea/ts/promise-function-async": "off",
                 "@eslint-community/mysticatea/ts/quotes": "off", // favor of Prettier.
                 "@eslint-community/mysticatea/ts/semi": "off", // favor of Prettier.
+                "@eslint-community/mysticatea/ts/space-before-blocks": "off", // favor of Prettier.
                 "@eslint-community/mysticatea/ts/strict-boolean-expressions":
                     "off",
                 "@eslint-community/mysticatea/ts/type-annotation-spacing":

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
         "eslint": ">=6.6.0"
     },
     "dependencies": {
-        "@typescript-eslint/eslint-plugin": "^2.34.0",
-        "@typescript-eslint/parser": "^2.34.0",
+        "@typescript-eslint/eslint-plugin": "^5.40.0",
+        "@typescript-eslint/parser": "^5.40.0",
         "eslint-plugin-eslint-comments": "^3.2.0",
         "eslint-plugin-eslint-plugin": "^2.3.0",
         "eslint-plugin-node": "^10.0.0",


### PR DESCRIPTION
Re-submission of https://github.com/mysticatea/eslint-plugin/pull/40

---

BREAKING CHANGE: `es5`, `es2015`, `es2016`, `es2017`, `es2018`, `es2019`, `es2020`, `es2021` & `es2022` configs now have extra rules from `@typescript-eslint/eslint-plugin`