### PR TITLE
feat: update `eslint-plugin-vue` & `vue-eslint-parser` + update configs

### DIFF
--- a/lib/configs/_override-vue.js
+++ b/lib/configs/_override-vue.js
@@ -48,10 +48,13 @@ module.exports = {
                     "error",
                 "@eslint-community/mysticatea/vue/component-name-in-template-casing":
                     ["error", "kebab-case"],
+                "@eslint-community/mysticatea/vue/component-options-name-casing":
+                    "error",
                 "@eslint-community/mysticatea/vue/component-tags-order":
                     "error",
                 "@eslint-community/mysticatea/vue/custom-event-name-casing":
                     "error",
+                "@eslint-community/mysticatea/vue/define-macros-order": "error",
                 "@eslint-community/mysticatea/vue/dot-location": "error",
                 "@eslint-community/mysticatea/vue/dot-notation": "error",
                 "@eslint-community/mysticatea/vue/eqeqeq": [
@@ -59,6 +62,8 @@ module.exports = {
                     "always",
                     { null: "ignore" },
                 ],
+                "@eslint-community/mysticatea/vue/first-attribute-linebreak":
+                    "error",
                 "@eslint-community/mysticatea/vue/func-call-spacing": "error",
                 "@eslint-community/mysticatea/vue/html-button-has-type":
                     "error",
@@ -80,15 +85,11 @@ module.exports = {
                 "@eslint-community/mysticatea/vue/keyword-spacing": "error",
                 "@eslint-community/mysticatea/vue/match-component-file-name":
                     "error",
+                "@eslint-community/mysticatea/vue/match-component-import-name":
+                    "error",
                 "@eslint-community/mysticatea/vue/max-attributes-per-line": [
                     "error",
-                    {
-                        singleline: 3,
-                        multiline: {
-                            max: 1,
-                            allowFirstLine: false,
-                        },
-                    },
+                    { multiline: 1, singleline: 3 },
                 ],
                 "@eslint-community/mysticatea/vue/max-len": [
                     "error",
@@ -110,6 +111,7 @@ module.exports = {
                 "@eslint-community/mysticatea/vue/no-bare-strings-in-template":
                     "error",
                 "@eslint-community/mysticatea/vue/no-boolean-default": "error",
+                "@eslint-community/mysticatea/vue/no-child-content": "error",
                 "@eslint-community/mysticatea/vue/no-computed-properties-in-data":
                     "error",
                 "@eslint-community/mysticatea/vue/no-constant-condition":
@@ -164,6 +166,8 @@ module.exports = {
                 "@eslint-community/mysticatea/vue/no-empty-pattern": "error",
                 "@eslint-community/mysticatea/vue/no-export-in-script-setup":
                     "error",
+                "@eslint-community/mysticatea/vue/no-expose-after-await":
+                    "error",
                 "@eslint-community/mysticatea/vue/no-extra-parens": "error",
                 "@eslint-community/mysticatea/vue/no-invalid-model-keys":
                     "error",
@@ -172,6 +176,7 @@ module.exports = {
                 "@eslint-community/mysticatea/vue/no-lifecycle-after-await":
                     "error",
                 "@eslint-community/mysticatea/vue/no-lone-template": "error",
+                "@eslint-community/mysticatea/vue/no-loss-of-precision": "off", // requires ESLint v7.1
                 "@eslint-community/mysticatea/vue/no-multiple-objects-in-class":
                     "error",
                 "@eslint-community/mysticatea/vue/no-multiple-slot-args":
@@ -187,6 +192,7 @@ module.exports = {
                 "@eslint-community/mysticatea/vue/no-reserved-component-names":
                     "error",
                 "@eslint-community/mysticatea/vue/no-reserved-keys": "error",
+                "@eslint-community/mysticatea/vue/no-reserved-props": "error",
                 "@eslint-community/mysticatea/vue/no-restricted-block": "error",
                 "@eslint-community/mysticatea/vue/no-restricted-call-after-await":
                     "error",
@@ -194,6 +200,8 @@ module.exports = {
                 "@eslint-community/mysticatea/vue/no-restricted-component-options":
                     "error",
                 "@eslint-community/mysticatea/vue/no-restricted-custom-event":
+                    "error",
+                "@eslint-community/mysticatea/vue/no-restricted-html-elements":
                     "error",
                 "@eslint-community/mysticatea/vue/no-restricted-props": "error",
                 "@eslint-community/mysticatea/vue/no-restricted-static-attribute":
@@ -219,9 +227,8 @@ module.exports = {
                     "error",
                 "@eslint-community/mysticatea/vue/no-this-in-before-route-enter":
                     "error",
+                "@eslint-community/mysticatea/vue/no-undef-components": "error",
                 "@eslint-community/mysticatea/vue/no-undef-properties": "error",
-                "@eslint-community/mysticatea/vue/no-unregistered-components":
-                    "error",
                 "@eslint-community/mysticatea/vue/no-unsupported-features":
                     "error",
                 "@eslint-community/mysticatea/vue/no-unused-components":
@@ -247,6 +254,8 @@ module.exports = {
                 "@eslint-community/mysticatea/vue/no-v-html": "error",
                 "@eslint-community/mysticatea/vue/no-v-model-argument": "error",
                 "@eslint-community/mysticatea/vue/no-v-text": "error",
+                "@eslint-community/mysticatea/vue/no-v-text-v-html-on-component":
+                    "error",
                 "@eslint-community/mysticatea/vue/no-watch-after-await":
                     "error",
                 "@eslint-community/mysticatea/vue/object-curly-newline":
@@ -257,13 +266,26 @@ module.exports = {
                 ],
                 "@eslint-community/mysticatea/vue/object-property-newline":
                     "error",
+                "@eslint-community/mysticatea/vue/object-shorthand": [
+                    "error",
+                    "always",
+                    { avoidExplicitReturnArrows: true },
+                ],
                 "@eslint-community/mysticatea/vue/one-component-per-file":
                     "error",
                 "@eslint-community/mysticatea/vue/operator-linebreak": "error",
                 "@eslint-community/mysticatea/vue/order-in-components": "error",
                 "@eslint-community/mysticatea/vue/padding-line-between-blocks":
                     "error",
+                "@eslint-community/mysticatea/vue/prefer-import-from-vue":
+                    "error",
+                "@eslint-community/mysticatea/vue/prefer-prop-type-boolean-first":
+                    "error",
+                "@eslint-community/mysticatea/vue/prefer-separate-static-class":
+                    "error",
                 "@eslint-community/mysticatea/vue/prefer-template": "error",
+                "@eslint-community/mysticatea/vue/prefer-true-attribute-shorthand":
+                    "error",
                 "@eslint-community/mysticatea/vue/prop-name-casing": "error",
                 "@eslint-community/mysticatea/vue/require-component-is":
                     "error",
@@ -340,6 +362,7 @@ module.exports = {
 
                 // Disabled rules (prefer prettier)
                 "@eslint-community/mysticatea/vue/no-restricted-syntax": "off",
+                "@eslint-community/mysticatea/vue/quote-props": "off",
                 "@eslint-community/mysticatea/vue/script-indent": "off",
             },
         },

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
         "eslint-plugin-eslint-plugin": "^4.4.1",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-prettier": "^3.4.1",
-        "eslint-plugin-vue": "^7.20.0",
+        "eslint-plugin-vue": "^8.7.1",
         "prettier": "^2.7.1",
-        "vue-eslint-parser": "^7.11.0"
+        "vue-eslint-parser": "^8.3.0"
     },
     "devDependencies": {
         "@eslint-community/eslint-plugin-mysticatea": "file:.",


### PR DESCRIPTION
Follow-up of #25 (see https://github.com/eslint-community/eslint-plugin-mysticatea/pull/25#discussion_r996498239)

---

BREAKING CHANGE: `es5`, `es2015`, `es2016`, `es2017`, `es2018`, `es2019`, `es2020`, `es2021` & `es2022` configs now have extra rules from `eslint-plugin-vue`