### PR TITLE
fix: use tilde instead of caret for dependencies that could break CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,19 +42,19 @@
         "watch": "mocha \"tests/lib/**/*.js\" --reporter dot --watch --growl"
     },
     "dependencies": {
-        "@typescript-eslint/eslint-plugin": "^5.40.0",
-        "@typescript-eslint/parser": "^5.40.0",
-        "eslint-plugin-eslint-comments": "^3.2.0",
-        "eslint-plugin-eslint-plugin": "^4.4.1",
-        "eslint-plugin-node": "^11.1.0",
-        "eslint-plugin-prettier": "^3.4.1",
-        "eslint-plugin-vue": "^8.7.1",
-        "prettier": "^2.7.1",
+        "@typescript-eslint/eslint-plugin": "~5.40.0",
+        "@typescript-eslint/parser": "~5.40.0",
+        "eslint-plugin-eslint-comments": "~3.2.0",
+        "eslint-plugin-eslint-plugin": "~4.4.1",
+        "eslint-plugin-node": "~11.1.0",
+        "eslint-plugin-prettier": "~3.4.1",
+        "eslint-plugin-vue": "~8.7.1",
+        "prettier": "~2.7.1",
         "vue-eslint-parser": "^8.3.0"
     },
     "devDependencies": {
         "@eslint-community/eslint-plugin-mysticatea": "file:.",
-        "eslint": "^6.8.0",
+        "eslint": "~6.8.0",
         "fs-extra": "^8.1.0",
         "globals": "^13.17.0",
         "mocha": "^9.2.2",


### PR DESCRIPTION
I'm in dubio here, as using carets (`^`) won't cause problems like https://github.com/mysticatea/eslint4b/pull/14#issuecomment-903315268

On the other hand, CI will break once one of these packages release a minor update that includes adding/deprecating a rule, because we have scheduled workflow runs.
Tests will also fail once we update locally.

Since adding a new rule to a config is a breaking change (as it can cause more linting errors), I think it's OK to use tilde (`~`) instead.

@eslint-community/core-team @eslint-community/mysticatea-eslint-plugin WDYT about this?
Do you maybe have a better solution?