### PR TITLE
chore: remove `fs-extra` from `devDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "devDependencies": {
         "@eslint-community/eslint-plugin-mysticatea": "file:.",
         "eslint": "~6.8.0",
-        "fs-extra": "^8.1.0",
         "globals": "^13.17.0",
         "mocha": "^9.2.2",
         "npm-run-all": "^4.1.5",


### PR DESCRIPTION
It's never used anywhere in the codebase