### PR TITLE
feat: support ESLint 8.x

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ jobs:
         name: ⬣ Lint (ESLint@${{ matrix.eslint }})
         strategy:
             matrix:
-                eslint: [6, 7]
+                eslint: [6, 7, 8]
         runs-on: ubuntu-latest
         steps:
             - name: 🛑 Cancel Previous Runs
@@ -47,18 +47,21 @@ jobs:
             matrix.os }})
         strategy:
             matrix:
-                eslint: [7]
+                eslint: [8]
                 node: [12.22.0, 12, 14.17.0, 14, 16, 18]
                 os: [ubuntu-latest]
                 include:
                     # On other platforms
                     - os: windows-latest
-                      eslint: 7
+                      eslint: 8
                       node: 18
                     - os: macos-latest
-                      eslint: 7
+                      eslint: 8
                       node: 18
                     # On old ESLint versions
+                    - eslint: 7
+                      node: 18
+                      os: ubuntu-latest
                     - eslint: 6
                       node: 18
                       os: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npm install --save-dev eslint @eslint-community/eslint-plugin-mysticatea
 ### Requirements
 
 -   Node.js `^12.22.0 || ^14.17.0 || >=16.0.0` or newer versions.
--   ESLint `^6.6.0 || ^7.0.0` or newer versions.
+-   ESLint `^6.6.0 || ^7.0.0 || ^8.0.0` or newer versions.
 
 ## 📖 Usage
 

--- a/lib/configs/_base.js
+++ b/lib/configs/_base.js
@@ -7,6 +7,7 @@
 const { Linter } = require("eslint")
 
 const isESLint7 = Linter.version.startsWith("7")
+const isESLint8 = Linter.version.startsWith("8")
 
 /** @type {import('eslint').Linter.Config} */
 module.exports = {
@@ -32,7 +33,7 @@ module.exports = {
         "consistent-return": "error",
         curly: "error",
         "default-case": "error",
-        ...(isESLint7 ? { "default-case-last": "off" } : {}), // TODO: enable once we drop ESLint v6 support
+        ...(isESLint7 || isESLint8 ? { "default-case-last": "off" } : {}), // TODO: enable once we drop ESLint v6 support
         "default-param-last": "error",
         "dot-notation": "error",
         eqeqeq: ["error", "always", { null: "ignore" }],
@@ -43,6 +44,7 @@ module.exports = {
         "init-declarations": "error",
         "linebreak-style": ["error", "unix"],
         "lines-between-class-members": "error",
+        ...(isESLint8 ? { "logical-assignment-operators": "off" } : {}), // TODO: enable once we drop ESLint v7 support
         "max-statements-per-line": ["error", { max: 1 }],
         "multiline-comment-style": ["error", "separate-lines"],
         "new-cap": "error",
@@ -53,6 +55,7 @@ module.exports = {
         "no-case-declarations": "error",
         "no-compare-neg-zero": "error",
         "no-cond-assign": "error",
+        ...(isESLint8 ? { "no-constant-binary-expression": "off" } : {}), // TODO: enable once we drop ESLint v7 support
         "no-constant-condition": "error",
         "no-constructor-return": "error",
         "no-control-regex": "error",
@@ -68,6 +71,7 @@ module.exports = {
         "no-empty-character-class": "error",
         "no-empty-function": "error",
         "no-empty-pattern": "error",
+        ...(isESLint8 ? { "no-empty-static-block": "off" } : {}), // TODO: enable once we drop ESLint v7 support
         "no-eval": "error",
         "no-ex-assign": "error",
         "no-extend-native": "error",
@@ -98,7 +102,7 @@ module.exports = {
         "no-lone-blocks": "error",
         "no-lonely-if": "error",
         "no-loop-func": "error",
-        ...(isESLint7 ? { "no-loss-of-precision": "off" } : {}), // TODO: enable once we drop ESLint v6 support
+        ...(isESLint7 || isESLint8 ? { "no-loss-of-precision": "off" } : {}), // TODO: enable once we drop ESLint v6 support
         "no-misleading-character-class": "error",
         "no-mixed-operators": [
             "error",
@@ -110,17 +114,22 @@ module.exports = {
             },
         ],
         "no-new": "error",
+        ...(isESLint8 ? { "no-new-native-nonconstructor": "off" } : {}), // TODO: enable once we drop ESLint v7 support
         "no-new-object": "error",
         "no-new-require": "error",
         "no-new-wrappers": "error",
-        ...(isESLint7 ? { "no-nonoctal-decimal-escape": "off" } : {}), // TODO: enable once we drop ESLint v6 support
+        ...(isESLint7 || isESLint8
+            ? { "no-nonoctal-decimal-escape": "off" }
+            : {}), // TODO: enable once we drop ESLint v6 support
         "no-obj-calls": "error",
         "no-octal": "error",
         "no-octal-escape": "error",
         "no-param-reassign": ["error", { props: false }],
         "no-process-env": "error",
         "no-process-exit": "error",
-        ...(isESLint7 ? { "no-promise-executor-return": "off" } : {}), // TODO: enable once we drop ESLint v6 support
+        ...(isESLint7 || isESLint8
+            ? { "no-promise-executor-return": "off" }
+            : {}), // TODO: enable once we drop ESLint v6 support
         "no-prototype-builtins": "error",
         "no-redeclare": ["error", { builtinGlobals: true }],
         "no-regex-spaces": "error",
@@ -151,12 +160,15 @@ module.exports = {
         "no-unmodified-loop-condition": "error",
         "no-unneeded-ternary": "error",
         "no-unreachable": "error",
-        ...(isESLint7 ? { "no-unreachable-loop": "off" } : {}), // TODO: enable once we drop ESLint v6 support
+        ...(isESLint7 || isESLint8 ? { "no-unreachable-loop": "off" } : {}), // TODO: enable once we drop ESLint v6 support
         "no-unsafe-finally": "error",
         "no-unsafe-negation": ["error", { enforceForOrderingRelations: true }],
-        ...(isESLint7 ? { "no-unsafe-optional-chaining": "off" } : {}), // TODO: enable once we drop ESLint v6 support
+        ...(isESLint7 || isESLint8
+            ? { "no-unsafe-optional-chaining": "off" }
+            : {}), // TODO: enable once we drop ESLint v6 support
         "no-unused-expressions": "error",
         "no-unused-labels": "error",
+        ...(isESLint8 ? { "no-unused-private-class-members": "off" } : {}), // TODO: enable once we drop ESLint v7 support
         "no-unused-vars": [
             "error",
             {
@@ -168,7 +180,9 @@ module.exports = {
             },
         ],
         "no-use-before-define": ["error", "nofunc"],
-        ...(isESLint7 ? { "no-useless-backreference": "off" } : {}), // TODO: enable once we drop ESLint v6 support
+        ...(isESLint7 || isESLint8
+            ? { "no-useless-backreference": "off" }
+            : {}), // TODO: enable once we drop ESLint v6 support
         "no-useless-call": "error",
         "no-useless-catch": "error",
         "no-useless-concat": "error",
@@ -190,6 +204,7 @@ module.exports = {
             { blankLine: "always", next: "*", prev: "function" },
         ],
         "prefer-exponentiation-operator": "error",
+        ...(isESLint8 ? { "prefer-object-has-own": "off" } : {}), // TODO: enable once we drop ESLint v7 support
         "prefer-promise-reject-errors": "error",
         "prefer-regex-literals": "error",
         quotes: ["error", "double", { avoidEscape: true }],

--- a/package.json
+++ b/package.json
@@ -53,9 +53,9 @@
         "vue-eslint-parser": "^8.3.0"
     },
     "devDependencies": {
-        "@eslint/eslintrc": "^0.4.3",
+        "@eslint/eslintrc": "^1.3.3",
         "@eslint-community/eslint-plugin-mysticatea": "file:.",
-        "eslint": "~7.32.0",
+        "eslint": "~8.27.0",
         "globals": "^13.17.0",
         "mocha": "^9.2.2",
         "npm-run-all": "^4.1.5",
@@ -65,7 +65,7 @@
         "typescript": "^4.8.4"
     },
     "peerDependencies": {
-        "eslint": ">=6.6.0"
+        "eslint": "^6.6.0 || ^7.0.0 || ^8.0.0"
     },
     "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"

--- a/tests/lib/configs/_rules.js
+++ b/tests/lib/configs/_rules.js
@@ -6,13 +6,12 @@
 
 const { Linter } = require("eslint")
 const {
-    ConfigArrayFactory,
-} = require("@eslint/eslintrc/lib/config-array-factory")
-const Validator = require("eslint/lib/shared/config-validator")
-const { rules: removedRules } = require("eslint/conf/replacements.json")
+    Legacy: { ConfigArrayFactory, ConfigValidator },
+} = require("@eslint/eslintrc")
 const {
     rules: PluginRulesIndex,
 } = require("@eslint-community/eslint-plugin-mysticatea")
+const { rules: removedRules } = require("./eslint-replacements.json")
 
 const coreRules = new Linter().getRules()
 const pluginRules = new Map(
@@ -31,6 +30,7 @@ const deprecatedRuleNames = new Set(
 const removedRuleNames = new Set(Object.keys(removedRules))
 
 const configFactory = new ConfigArrayFactory()
+const configValidator = new ConfigValidator()
 
 module.exports = {
     /**
@@ -40,7 +40,9 @@ module.exports = {
      * @returns {void}
      */
     validateConfig(config, source) {
-        Validator.validate(config, source, (ruleId) => allRules.get(ruleId))
+        configValidator.validate(config, source, (ruleId) =>
+            allRules.get(ruleId)
+        )
 
         /* istanbul ignore next */
         for (const ruleId of [].concat(

--- a/tests/lib/configs/eslint-replacements.json
+++ b/tests/lib/configs/eslint-replacements.json
@@ -1,0 +1,26 @@
+{
+    "rules": {
+        "generator-star": ["generator-star-spacing"],
+        "global-strict": ["strict"],
+        "no-arrow-condition": ["no-confusing-arrow", "no-constant-condition"],
+        "no-comma-dangle": ["comma-dangle"],
+        "no-empty-class": ["no-empty-character-class"],
+        "no-empty-label": ["no-labels"],
+        "no-extra-strict": ["strict"],
+        "no-reserved-keys": ["quote-props"],
+        "no-space-before-semi": ["semi-spacing"],
+        "no-wrap-func": ["no-extra-parens"],
+        "space-after-function-name": ["space-before-function-paren"],
+        "space-after-keywords": ["keyword-spacing"],
+        "space-before-function-parentheses": ["space-before-function-paren"],
+        "space-before-keywords": ["keyword-spacing"],
+        "space-in-brackets": [
+            "object-curly-spacing",
+            "array-bracket-spacing",
+            "computed-property-spacing"
+        ],
+        "space-return-throw-case": ["keyword-spacing"],
+        "space-unary-word-ops": ["space-unary-ops"],
+        "spaced-line-comment": ["spaced-comment"]
+    }
+}


### PR DESCRIPTION
Re-submission of https://github.com/mysticatea/eslint-plugin/pull/32

> ESLint v8.0.0 is [released](https://eslint.org/blog/2021/10/eslint-v8.0.0-released) 🎉
> 
> Dependencies should be compatible with ESLint 8 too before we can merge this one:
> 
> - [x] [`@typescript-eslint/eslint-plugin`](https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/eslint-plugin) (https://github.com/typescript-eslint/typescript-eslint/issues/3738)
>   - [x] https://github.com/typescript-eslint/typescript-eslint/pull/3737
>   - [x] https://github.com/typescript-eslint/typescript-eslint/pull/3767
>   - [x] https://github.com/typescript-eslint/typescript-eslint/pull/3768
>   - [x] https://github.com/typescript-eslint/typescript-eslint/pull/3800
>   - [x] https://github.com/typescript-eslint/typescript-eslint/pull/3806
>   - [x] https://github.com/typescript-eslint/typescript-eslint/pull/3808
>   - [x] https://github.com/typescript-eslint/typescript-eslint/pull/3809
>   - [x] [`v5.0.0`](https://github.com/typescript-eslint/typescript-eslint/releases/tag/v5.0.0)
> - [x] [`@typescript-eslint/parser`](https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/parser) (https://github.com/typescript-eslint/typescript-eslint/issues/3738)
>   - [x] https://github.com/typescript-eslint/typescript-eslint/pull/3737
>   - [x] https://github.com/typescript-eslint/typescript-eslint/pull/3767
>   - [x] https://github.com/typescript-eslint/typescript-eslint/pull/3768
>   - [x] https://github.com/typescript-eslint/typescript-eslint/pull/3800
>   - [x] https://github.com/typescript-eslint/typescript-eslint/pull/3806
>   - [x] https://github.com/typescript-eslint/typescript-eslint/pull/3808
>   - [x] https://github.com/typescript-eslint/typescript-eslint/pull/3809
>   - [x] [`v5.0.0`](https://github.com/typescript-eslint/typescript-eslint/releases/tag/v5.0.0)
> - [ ] [`eslint-plugin-eslint-comments`](https://github.com/mysticatea/eslint-plugin-eslint-comments) (https://github.com/mysticatea/eslint-plugin-eslint-comments/issues/62)
>   - [ ] https://github.com/mysticatea/eslint-plugin-eslint-comments/pull/63
>   - [ ] Release
> - [x] [`eslint-plugin-eslint-plugin`](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin) (https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/issues/175)
>   - [x] https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/pull/119
>   - [x] https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/pull/151
>   - [x] https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/pull/186
>   - [x] https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/pull/212
>   - [x] [`v4.0.0-0`](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/master/CHANGELOG.md#v400-0)
>   - [x] [`v4.0.0`](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/releases/tag/v4.0.0)
> - [ ] [`eslint-plugin-node`](https://github.com/mysticatea/eslint-plugin-node) (https://github.com/mysticatea/eslint-plugin-node/issues/294)
>   - [ ] https://github.com/mysticatea/eslint-plugin-node/pull/224
>   - [ ] https://github.com/mysticatea/eslint-plugin-node/pull/295
>   - [ ] Release
> - [x] [`eslint-plugin-prettier`](https://github.com/prettier/eslint-plugin-prettier) (https://github.com/prettier/eslint-plugin-prettier/issues/427)
>   - [x] https://github.com/prettier/eslint-plugin-prettier/pull/428
>   - [x] ~Release~
> - [x] [`eslint-plugin-vue`](https://github.com/vuejs/eslint-plugin-vue) (https://github.com/vuejs/eslint-plugin-vue/issues/1615)
>   - [x] https://github.com/vuejs/eslint-plugin-vue/pull/1588
>   - [x] https://github.com/vuejs/eslint-plugin-vue/pull/1610
>   - [x] [`v8.0.0`](https://github.com/vuejs/eslint-plugin-vue/releases/tag/v8.0.0)
> 
> ---
> 
> Closes https://github.com/mysticatea/eslint-plugin/issues/31