### PR TITLE
fix: don't add rules if they're not available

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,10 @@ on:
 
 jobs:
     lint:
-        name: ⬣ Lint
+        name: ⬣ Lint (ESLint@${{ matrix.eslint }})
+        strategy:
+            matrix:
+                eslint: [6, 7]
         runs-on: ubuntu-latest
         steps:
             - name: 🛑 Cancel Previous Runs
@@ -31,6 +34,9 @@ jobs:
 
             - name: 📥 Install dependencies
               run: npm install
+
+            - name: 📥 Install ESLint v${{ matrix.eslint }}
+              run: npm install --save-dev eslint@${{ matrix.eslint }}
 
             - name: ▶️ Run lint script
               run: npm run lint

--- a/lib/configs/_base.js
+++ b/lib/configs/_base.js
@@ -4,6 +4,11 @@
  */
 "use strict"
 
+const { Linter } = require("eslint")
+
+const isESLint7 = Linter.version.startsWith("7")
+
+/** @type {import('eslint').Linter.Config} */
 module.exports = {
     root: true,
     plugins: ["@eslint-community/mysticatea"],
@@ -27,7 +32,7 @@ module.exports = {
         "consistent-return": "error",
         curly: "error",
         "default-case": "error",
-        "default-case-last": "error",
+        ...(isESLint7 ? { "default-case-last": "off" } : {}), // TODO: enable once we drop ESLint v6 support
         "default-param-last": "error",
         "dot-notation": "error",
         eqeqeq: ["error", "always", { null: "ignore" }],
@@ -93,7 +98,7 @@ module.exports = {
         "no-lone-blocks": "error",
         "no-lonely-if": "error",
         "no-loop-func": "error",
-        "no-loss-of-precision": "error",
+        ...(isESLint7 ? { "no-loss-of-precision": "off" } : {}), // TODO: enable once we drop ESLint v6 support
         "no-misleading-character-class": "error",
         "no-mixed-operators": [
             "error",
@@ -108,14 +113,14 @@ module.exports = {
         "no-new-object": "error",
         "no-new-require": "error",
         "no-new-wrappers": "error",
-        "no-nonoctal-decimal-escape": "error",
+        ...(isESLint7 ? { "no-nonoctal-decimal-escape": "off" } : {}), // TODO: enable once we drop ESLint v6 support
         "no-obj-calls": "error",
         "no-octal": "error",
         "no-octal-escape": "error",
         "no-param-reassign": ["error", { props: false }],
         "no-process-env": "error",
         "no-process-exit": "error",
-        "no-promise-executor-return": "error",
+        ...(isESLint7 ? { "no-promise-executor-return": "off" } : {}), // TODO: enable once we drop ESLint v6 support
         "no-prototype-builtins": "error",
         "no-redeclare": ["error", { builtinGlobals: true }],
         "no-regex-spaces": "error",
@@ -146,10 +151,10 @@ module.exports = {
         "no-unmodified-loop-condition": "error",
         "no-unneeded-ternary": "error",
         "no-unreachable": "error",
-        "no-unreachable-loop": "error",
+        ...(isESLint7 ? { "no-unreachable-loop": "off" } : {}), // TODO: enable once we drop ESLint v6 support
         "no-unsafe-finally": "error",
         "no-unsafe-negation": ["error", { enforceForOrderingRelations: true }],
-        "no-unsafe-optional-chaining": "error",
+        ...(isESLint7 ? { "no-unsafe-optional-chaining": "off" } : {}), // TODO: enable once we drop ESLint v6 support
         "no-unused-expressions": "error",
         "no-unused-labels": "error",
         "no-unused-vars": [
@@ -163,7 +168,7 @@ module.exports = {
             },
         ],
         "no-use-before-define": ["error", "nofunc"],
-        "no-useless-backreference": "error",
+        ...(isESLint7 ? { "no-useless-backreference": "off" } : {}), // TODO: enable once we drop ESLint v6 support
         "no-useless-call": "error",
         "no-useless-catch": "error",
         "no-useless-concat": "error",


### PR DESCRIPTION
These rules were added in #28, but are throwing an error if we use ESLint v6
https://github.com/eslint-community/eslint-plugin-mysticatea/actions/runs/3465932690/jobs/5789231340

I also disabled all rules, as it was against our semver policy to add new potential errors in a minor release