### PR TITLE
feat: turn off `prettier` conflicting rules

### DIFF
--- a/lib/configs/_override-ts.js
+++ b/lib/configs/_override-ts.js
@@ -25,8 +25,6 @@ module.exports = {
                 "@eslint-community/mysticatea/ts/ban-tslint-comment": "error",
                 "@eslint-community/mysticatea/ts/class-literal-property-style":
                     "error",
-                "@eslint-community/mysticatea/ts/comma-dangle": "error",
-                "@eslint-community/mysticatea/ts/comma-spacing": "error",
                 "@eslint-community/mysticatea/ts/consistent-generic-constructors":
                     "error",
                 "@eslint-community/mysticatea/ts/consistent-indexed-object-style":
@@ -44,7 +42,6 @@ module.exports = {
                 "@eslint-community/mysticatea/ts/explicit-module-boundary-types":
                     "error",
                 "@eslint-community/mysticatea/ts/init-declarations": "error",
-                "@eslint-community/mysticatea/ts/keyword-spacing": "error",
                 "@eslint-community/mysticatea/ts/lines-between-class-members":
                     "error",
                 "@eslint-community/mysticatea/ts/method-signature-style":
@@ -64,7 +61,6 @@ module.exports = {
                 "@eslint-community/mysticatea/ts/no-empty-interface": "error",
                 "@eslint-community/mysticatea/ts/no-extra-non-null-assertion":
                     "error",
-                "@eslint-community/mysticatea/ts/no-extra-semi": "error",
                 "@eslint-community/mysticatea/ts/no-extraneous-class": "error",
                 "@eslint-community/mysticatea/ts/no-floating-promises": "error",
                 "@eslint-community/mysticatea/ts/no-for-in-array": "error",
@@ -125,7 +121,6 @@ module.exports = {
                 "@eslint-community/mysticatea/ts/no-var-requires": "error",
                 "@eslint-community/mysticatea/ts/non-nullable-type-assertion-style":
                     "error",
-                "@eslint-community/mysticatea/ts/object-curly-spacing": "error",
                 "@eslint-community/mysticatea/ts/padding-line-between-statements":
                     "error",
                 "@eslint-community/mysticatea/ts/parameter-properties": "error",
@@ -164,9 +159,6 @@ module.exports = {
                 "@eslint-community/mysticatea/ts/return-await": "error",
                 "@eslint-community/mysticatea/ts/sort-type-union-intersection-members":
                     "error",
-                "@eslint-community/mysticatea/ts/space-before-function-paren":
-                    "error",
-                "@eslint-community/mysticatea/ts/space-infix-ops": "error",
                 "@eslint-community/mysticatea/ts/switch-exhaustiveness-check":
                     "error",
                 "@eslint-community/mysticatea/ts/triple-slash-reference":
@@ -214,16 +206,20 @@ module.exports = {
                 "one-var": "off",
                 "@eslint-community/mysticatea/ts/ban-types": "off",
                 "@eslint-community/mysticatea/ts/brace-style": "off", // favor of Prettier.
+                "@eslint-community/mysticatea/ts/comma-dangle": "off", // favor of Prettier.
+                "@eslint-community/mysticatea/ts/comma-spacing": "off", // favor of Prettier.
                 "@eslint-community/mysticatea/ts/consistent-type-definitions":
                     "off",
                 "@eslint-community/mysticatea/ts/explicit-function-return-type":
                     "off", // I want but this is not so...
                 "@eslint-community/mysticatea/ts/func-call-spacing": "off", // favor of Prettier.
                 "@eslint-community/mysticatea/ts/indent": "off", // favor of Prettier.
+                "@eslint-community/mysticatea/ts/keyword-spacing": "off", // favor of Prettier.
                 "@eslint-community/mysticatea/ts/member-delimiter-style": "off", // favor of Prettier.
                 "@eslint-community/mysticatea/ts/member-ordering": "off",
                 "@eslint-community/mysticatea/ts/no-explicit-any": "off",
                 "@eslint-community/mysticatea/ts/no-extra-parens": "off", // favor of Prettier.
+                "@eslint-community/mysticatea/ts/no-extra-semi": "off", // favor of Prettier.
                 "@eslint-community/mysticatea/ts/no-magic-numbers": "off",
                 "@eslint-community/mysticatea/ts/no-namespace": "off", // I like the namespace for interfaces (type only things).
                 "@eslint-community/mysticatea/ts/no-non-null-assertion": "off",
@@ -232,11 +228,15 @@ module.exports = {
                     "off", // This was problematic for test code.
                 "@eslint-community/mysticatea/ts/no-unused-vars": "off", // tsc verifies it.
                 "@eslint-community/mysticatea/ts/no-use-before-define": "off", // tsc verifies it.
+                "@eslint-community/mysticatea/ts/object-curly-spacing": "off", // favor of Prettier.
                 "@eslint-community/mysticatea/ts/prefer-for-of": "off",
                 "@eslint-community/mysticatea/ts/promise-function-async": "off",
                 "@eslint-community/mysticatea/ts/quotes": "off", // favor of Prettier.
                 "@eslint-community/mysticatea/ts/semi": "off", // favor of Prettier.
                 "@eslint-community/mysticatea/ts/space-before-blocks": "off", // favor of Prettier.
+                "@eslint-community/mysticatea/ts/space-before-function-paren":
+                    "off", // favor of Prettier.
+                "@eslint-community/mysticatea/ts/space-infix-ops": "off", // favor of Prettier.
                 "@eslint-community/mysticatea/ts/strict-boolean-expressions":
                     "off",
                 "@eslint-community/mysticatea/ts/type-annotation-spacing":

--- a/lib/configs/_override-vue.js
+++ b/lib/configs/_override-vue.js
@@ -15,33 +15,11 @@ module.exports = {
             parser: require.resolve("vue-eslint-parser"),
             rules: {
                 // Enabled rules
-                "@eslint-community/mysticatea/vue/array-bracket-newline":
-                    "error",
-                "@eslint-community/mysticatea/vue/array-bracket-spacing": [
-                    "error",
-                    "never",
-                ],
-                "@eslint-community/mysticatea/vue/arrow-spacing": "error",
                 "@eslint-community/mysticatea/vue/attribute-hyphenation":
                     "error",
                 "@eslint-community/mysticatea/vue/attributes-order": "error",
                 "@eslint-community/mysticatea/vue/block-lang": "error",
-                "@eslint-community/mysticatea/vue/block-spacing": "error",
-                "@eslint-community/mysticatea/vue/block-tag-newline": "error",
-                "@eslint-community/mysticatea/vue/brace-style": "error",
                 "@eslint-community/mysticatea/vue/camelcase": "error",
-                "@eslint-community/mysticatea/vue/comma-dangle": [
-                    "error",
-                    {
-                        arrays: "always",
-                        objects: "always",
-                        imports: "always",
-                        exports: "always",
-                        functions: "always",
-                    },
-                ],
-                "@eslint-community/mysticatea/vue/comma-spacing": "error",
-                "@eslint-community/mysticatea/vue/comma-style": "error",
                 "@eslint-community/mysticatea/vue/comment-directive": "error",
                 "@eslint-community/mysticatea/vue/component-api-style": "error",
                 "@eslint-community/mysticatea/vue/component-definition-name-casing":
@@ -55,7 +33,6 @@ module.exports = {
                 "@eslint-community/mysticatea/vue/custom-event-name-casing":
                     "error",
                 "@eslint-community/mysticatea/vue/define-macros-order": "error",
-                "@eslint-community/mysticatea/vue/dot-location": "error",
                 "@eslint-community/mysticatea/vue/dot-notation": "error",
                 "@eslint-community/mysticatea/vue/eqeqeq": [
                     "error",
@@ -64,42 +41,14 @@ module.exports = {
                 ],
                 "@eslint-community/mysticatea/vue/first-attribute-linebreak":
                     "error",
-                "@eslint-community/mysticatea/vue/func-call-spacing": "error",
                 "@eslint-community/mysticatea/vue/html-button-has-type":
                     "error",
-                "@eslint-community/mysticatea/vue/html-closing-bracket-newline":
-                    ["error", { multiline: "always", singleline: "never" }],
-                "@eslint-community/mysticatea/vue/html-closing-bracket-spacing":
-                    "error",
-                "@eslint-community/mysticatea/vue/html-comment-content-newline":
-                    "error",
-                "@eslint-community/mysticatea/vue/html-comment-content-spacing":
-                    "error",
-                "@eslint-community/mysticatea/vue/html-comment-indent": "error",
-                "@eslint-community/mysticatea/vue/html-end-tags": "error",
-                "@eslint-community/mysticatea/vue/html-indent": ["error", 4],
-                "@eslint-community/mysticatea/vue/html-quotes": "error",
-                "@eslint-community/mysticatea/vue/html-self-closing": "error",
                 "@eslint-community/mysticatea/vue/jsx-uses-vars": "error",
-                "@eslint-community/mysticatea/vue/key-spacing": "error",
-                "@eslint-community/mysticatea/vue/keyword-spacing": "error",
                 "@eslint-community/mysticatea/vue/match-component-file-name":
                     "error",
                 "@eslint-community/mysticatea/vue/match-component-import-name":
                     "error",
-                "@eslint-community/mysticatea/vue/max-attributes-per-line": [
-                    "error",
-                    { multiline: 1, singleline: 3 },
-                ],
-                "@eslint-community/mysticatea/vue/max-len": [
-                    "error",
-                    { tabWidth: 4 },
-                ],
-                "@eslint-community/mysticatea/vue/multiline-html-element-content-newline":
-                    "error",
                 "@eslint-community/mysticatea/vue/multi-word-component-names":
-                    "error",
-                "@eslint-community/mysticatea/vue/mustache-interpolation-spacing":
                     "error",
                 "@eslint-community/mysticatea/vue/new-line-between-multi-line-property":
                     "error",
@@ -168,7 +117,6 @@ module.exports = {
                     "error",
                 "@eslint-community/mysticatea/vue/no-expose-after-await":
                     "error",
-                "@eslint-community/mysticatea/vue/no-extra-parens": "error",
                 "@eslint-community/mysticatea/vue/no-invalid-model-keys":
                     "error",
                 "@eslint-community/mysticatea/vue/no-irregular-whitespace":
@@ -183,7 +131,6 @@ module.exports = {
                     "error",
                 "@eslint-community/mysticatea/vue/no-multiple-template-root":
                     "error",
-                "@eslint-community/mysticatea/vue/no-multi-spaces": "error",
                 "@eslint-community/mysticatea/vue/no-mutating-props": "error",
                 "@eslint-community/mysticatea/vue/no-parsing-error": "error",
                 "@eslint-community/mysticatea/vue/no-potential-component-option-typo":
@@ -213,8 +160,6 @@ module.exports = {
                 "@eslint-community/mysticatea/vue/no-shared-component-data":
                     "error",
                 "@eslint-community/mysticatea/vue/no-side-effects-in-computed-properties":
-                    "error",
-                "@eslint-community/mysticatea/vue/no-spaces-around-equal-signs-in-attribute":
                     "error",
                 "@eslint-community/mysticatea/vue/no-sparse-arrays": "error",
                 "@eslint-community/mysticatea/vue/no-static-inline-styles":
@@ -258,14 +203,6 @@ module.exports = {
                     "error",
                 "@eslint-community/mysticatea/vue/no-watch-after-await":
                     "error",
-                "@eslint-community/mysticatea/vue/object-curly-newline":
-                    "error",
-                "@eslint-community/mysticatea/vue/object-curly-spacing": [
-                    "error",
-                    "always",
-                ],
-                "@eslint-community/mysticatea/vue/object-property-newline":
-                    "error",
                 "@eslint-community/mysticatea/vue/object-shorthand": [
                     "error",
                     "always",
@@ -273,7 +210,6 @@ module.exports = {
                 ],
                 "@eslint-community/mysticatea/vue/one-component-per-file":
                     "error",
-                "@eslint-community/mysticatea/vue/operator-linebreak": "error",
                 "@eslint-community/mysticatea/vue/order-in-components": "error",
                 "@eslint-community/mysticatea/vue/padding-line-between-blocks":
                     "error",
@@ -318,15 +254,8 @@ module.exports = {
                     "error",
                 "@eslint-community/mysticatea/vue/script-setup-uses-vars":
                     "error",
-                "@eslint-community/mysticatea/vue/singleline-html-element-content-newline":
-                    "error",
                 "@eslint-community/mysticatea/vue/sort-keys": "error",
-                "@eslint-community/mysticatea/vue/space-in-parens": "error",
-                "@eslint-community/mysticatea/vue/space-infix-ops": "error",
-                "@eslint-community/mysticatea/vue/space-unary-ops": "error",
                 "@eslint-community/mysticatea/vue/static-class-names-order":
-                    "error",
-                "@eslint-community/mysticatea/vue/template-curly-spacing":
                     "error",
                 "@eslint-community/mysticatea/vue/this-in-template": "error",
                 "@eslint-community/mysticatea/vue/use-v-on-exact": "error",
@@ -361,9 +290,58 @@ module.exports = {
                 "@eslint-community/mysticatea/vue/valid-v-text": "error",
 
                 // Disabled rules (prefer prettier)
+                "@eslint-community/mysticatea/vue/array-bracket-newline": "off",
+                "@eslint-community/mysticatea/vue/array-bracket-spacing": "off",
+                "@eslint-community/mysticatea/vue/arrow-spacing": "off",
+                "@eslint-community/mysticatea/vue/block-spacing": "off",
+                "@eslint-community/mysticatea/vue/block-tag-newline": "off",
+                "@eslint-community/mysticatea/vue/brace-style": "off",
+                "@eslint-community/mysticatea/vue/comma-dangle": "off",
+                "@eslint-community/mysticatea/vue/comma-spacing": "off",
+                "@eslint-community/mysticatea/vue/comma-style": "off",
+                "@eslint-community/mysticatea/vue/dot-location": "off",
+                "@eslint-community/mysticatea/vue/func-call-spacing": "off",
+                "@eslint-community/mysticatea/vue/html-closing-bracket-newline":
+                    "off",
+                "@eslint-community/mysticatea/vue/html-closing-bracket-spacing":
+                    "off",
+                "@eslint-community/mysticatea/vue/html-comment-content-newline":
+                    "off",
+                "@eslint-community/mysticatea/vue/html-comment-content-spacing":
+                    "off",
+                "@eslint-community/mysticatea/vue/html-comment-indent": "off",
+                "@eslint-community/mysticatea/vue/html-end-tags": "off",
+                "@eslint-community/mysticatea/vue/html-indent": "off",
+                "@eslint-community/mysticatea/vue/html-quotes": "off",
+                "@eslint-community/mysticatea/vue/html-self-closing": "off",
+                "@eslint-community/mysticatea/vue/key-spacing": "off",
+                "@eslint-community/mysticatea/vue/keyword-spacing": "off",
+                "@eslint-community/mysticatea/vue/max-attributes-per-line":
+                    "off",
+                "@eslint-community/mysticatea/vue/max-len": "off",
+                "@eslint-community/mysticatea/vue/multiline-html-element-content-newline":
+                    "off",
+                "@eslint-community/mysticatea/vue/mustache-interpolation-spacing":
+                    "off",
+                "@eslint-community/mysticatea/vue/no-extra-parens": "off",
+                "@eslint-community/mysticatea/vue/no-multi-spaces": "off",
                 "@eslint-community/mysticatea/vue/no-restricted-syntax": "off",
+                "@eslint-community/mysticatea/vue/no-spaces-around-equal-signs-in-attribute":
+                    "off",
+                "@eslint-community/mysticatea/vue/object-curly-newline": "off",
+                "@eslint-community/mysticatea/vue/object-curly-spacing": "off",
+                "@eslint-community/mysticatea/vue/object-property-newline":
+                    "off",
+                "@eslint-community/mysticatea/vue/operator-linebreak": "off",
                 "@eslint-community/mysticatea/vue/quote-props": "off",
                 "@eslint-community/mysticatea/vue/script-indent": "off",
+                "@eslint-community/mysticatea/vue/singleline-html-element-content-newline":
+                    "off",
+                "@eslint-community/mysticatea/vue/space-in-parens": "off",
+                "@eslint-community/mysticatea/vue/space-infix-ops": "off",
+                "@eslint-community/mysticatea/vue/space-unary-ops": "off",
+                "@eslint-community/mysticatea/vue/template-curly-spacing":
+                    "off",
             },
         },
     ],

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
         "@eslint-community/eslint-plugin-mysticatea": "file:.",
         "@eslint/eslintrc": "^1.3.3",
         "eslint": "~8.27.0",
+        "eslint-config-prettier": "^8.6.0",
         "globals": "^13.17.0",
         "mocha": "^9.2.2",
         "npm-run-all": "^4.1.5",


### PR DESCRIPTION
This PR changes the configuration to turn off rules that conflict with prettier.

I noticed this issue while checking the following PR.
https://github.com/eslint-community/regexpp/pull/31