### PR TITLE
Loosen the dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,14 +42,14 @@
         "watch": "mocha \"tests/lib/**/*.js\" --reporter dot --watch --growl"
     },
     "dependencies": {
-        "@typescript-eslint/eslint-plugin": "~5.59.1",
-        "@typescript-eslint/parser": "~5.59.1",
-        "eslint-plugin-eslint-comments": "~3.2.0",
-        "eslint-plugin-eslint-plugin": "~4.4.1",
-        "eslint-plugin-node": "~11.1.0",
-        "eslint-plugin-prettier": "~3.4.1",
-        "eslint-plugin-vue": "~8.7.1",
-        "prettier": "~2.7.1",
+        "@typescript-eslint/eslint-plugin": "^5.59.1",
+        "@typescript-eslint/parser": "^5.59.1",
+        "eslint-plugin-eslint-comments": "^3.2.0",
+        "eslint-plugin-eslint-plugin": "^4.4.1",
+        "eslint-plugin-node": "^11.1.0",
+        "eslint-plugin-prettier": "^3.4.1",
+        "eslint-plugin-vue": "^8.7.1",
+        "prettier": "^2.7.1",
         "semver": "^7.5.0",
         "vue-eslint-parser": "^8.3.0"
     },


### PR DESCRIPTION
So that people don't get multiple versions of these packages in their lock files if they use a newer version (like `@typescript-eslint` 5.60.0).

cc @MichaelDeBoey 