### PR TITLE
fix: generate provenance statements on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,12 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true
 
+permissions:
+  contents: write # to be able to publish a GitHub release
+  id-token: write # to enable use of OIDC for npm provenance
+  issues: write # to be able to comment on released issues
+  pull-requests: write # to be able to comment on released pull requests
+
 jobs:
     lint:
         name: ⬣ Lint (ESLint@${{ matrix.eslint }})
@@ -128,4 +134,5 @@ jobs:
                       ]
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  NPM_CONFIG_PROVENANCE: true
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This will also add a new Provenance section + a verified badge next to the version (in the sidebar + versions tab) to the NPM page

More info can be found at https://docs.npmjs.com/generating-provenance-statements