### PR TITLE
chore: flow-up for trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,9 +114,7 @@ jobs:
             - name: ⎔ Setup node
               uses: actions/setup-node@v4
               with:
-                  # node 24 is required for semantic-release@v25.
-                  # However, `lts/*` may point to v24 in the near future, so it's better to use `lts/*`.
-                  node-version: 24
+                  node-version: lts/*
 
               # npm 11.5.1 or later is required so update to latest to be sure
             - name: Update npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,9 +112,11 @@ jobs:
               uses: actions/checkout@v4
 
             - name: ⎔ Setup node
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
-                  node-version: 22
+                  # node 24 is required for semantic-release@v25.
+                  # However, `lts/*` may point to v24 in the near future, so it's better to use `lts/*`.
+                  node-version: 24
 
               # npm 11.5.1 or later is required so update to latest to be sure
             - name: Update npm
@@ -124,9 +126,11 @@ jobs:
               run: npm install
 
             - name: 🚀 Release
-              uses: cycjimmy/semantic-release-action@v4
+              uses: cycjimmy/semantic-release-action@v5
               with:
-                  semantic_version: 19
+                  # semantic-release@v25 is required for trusted publishing.
+                  # https://github.com/semantic-release/semantic-release/releases/tag/v25.0.1
+                  semantic_version: 25
                   branches: |
                       [
                         '+([0-9])?(.{+([0-9]),x}).x',


### PR DESCRIPTION
This PR changes the semantic-release configuration to allow trusted publishing.

Please see https://github.com/eslint-community/regexpp/pull/217, https://github.com/eslint-community/regexpp/pull/218


close #211